### PR TITLE
Fix typo in quick start code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,13 +79,13 @@ Quick Start
 
     # withdraw 100 ETH
     # check docs for assumptions around withdrawals
-    from binance.exceptions import BinanceApiException, BinanceWithdrawException
+    from binance.exceptions import BinanceAPIException, BinanceWithdrawException
     try:
         result = client.withdraw(
             asset='ETH',
             address='<eth_address>',
             amount=100)
-    except BinanceApiException as e:
+    except BinanceAPIException as e:
         print(e)
     except BinanceWithdrawException as e:
         print(e)


### PR DESCRIPTION
Capitalization of exception class name was wrong.