### PR TITLE
Using keyworded callback

### DIFF
--- a/PYPIREADME.rst
+++ b/PYPIREADME.rst
@@ -109,7 +109,7 @@ Quick Start
 
     from binance.websockets import BinanceSocketManager
     bm = BinanceSocketManager(client)
-    bm.start_aggtrade_socket(symbol='BNBBTC')
+    bm.start_aggtrade_socket(symbol='BNBBTC', callback=process_message)
     bm.start()
 
 For more `check out the documentation <https://python-binance.readthedocs.io/en/latest/>`_.

--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ Quick Start
 
     from binance.websockets import BinanceSocketManager
     bm = BinanceSocketManager(client)
-    bm.start_aggtrade_socket(symbol='BNBBTC')
+    bm.start_aggtrade_socket(symbol='BNBBTC', callback=process_message)
     bm.start()
 
 For more `check out the documentation <https://python-binance.readthedocs.io/en/latest/>`_.


### PR DESCRIPTION
The example throws an error when being run,

```
APIError(code=403): Access denied
Traceback (most recent call last):
  File "test.py", line 55, in <module>
    bm.start_aggtrade_socket(symbol='BNBBTC')
TypeError: start_aggtrade_socket() takes exactly 3 arguments (2 given)
```

And because the first argument is being called with a keyword, all subsequent arguments also require a keyword.