### PR TITLE
Catch different exceptions in the same line

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,9 +89,7 @@ Quick Start
             asset='ETH',
             address='<eth_address>',
             amount=100)
-    except BinanceAPIException as e:
-        print(e)
-    except BinanceWithdrawException as e:
+    except (BinanceAPIException, BinanceWithdrawException) as e:
         print(e)
     else:
         print("Success")


### PR DESCRIPTION
There is no need to write these as separate lines.