### PR TITLE
Minor fixes for building on Mac OS X using Brew

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .tox
 .cache/v/cache
 docs/_build
+binance/__pycache__/
+build/
+dist/
+python_binance.egg-info/

--- a/PYPIREADME.rst
+++ b/PYPIREADME.rst
@@ -1,5 +1,5 @@
 ================================
-Welcome to python-binance v0.6.1
+Welcome to python-binance v0.6.2
 ================================
 
 .. image:: https://img.shields.io/pypi/v/python-binance.svg

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ================================
-Welcome to python-binance v0.6.1
+Welcome to python-binance v0.6.2
 ================================
 
 .. image:: https://img.shields.io/pypi/v/python-binance.svg

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v0.6.2 - 2018-01-12
+^^^^^^^^^^^^^^^^^^^
+
+**Fixes**
+
+- fixed handling Binance errors that aren't JSON objects
+
 v0.6.1 - 2018-01-10
 ^^^^^^^^^^^^^^^^^^^
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='python-binance',
-    version='0.6.1',
+    version='0.6.2',
     packages=['binance'],
     description='Binance REST API python implementation',
     url='https://github.com/sammchardy/python-binance',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author='Sam McHardy',
     license='MIT',
     author_email='',
-    install_requires=['requests', 'six', 'Twisted', 'pyOpenSSL', 'autobahn', 'service-identity', 'dateparser'],
+    install_requires=['requests', 'six', 'Twisted', 'pyOpenSSL', 'autobahn', 'service-identity', 'dateparser', 'urllib3'],
     keywords='binance exchange rest api bitcoin ethereum btc eth neo',
     classifiers=[
           'Intended Audience :: Developers',


### PR DESCRIPTION
Changes to `.gitignore` and `setup.py` for successful build and install on Mac 10.13.2 (17C88) using Homebrew 1.4.3.