### PR TITLE
Fixed the max on the get_order_book limit param.

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -444,7 +444,7 @@ class Client(object):
 
         :param symbol: required
         :type symbol: str
-        :param limit:  Default 100; max 100
+        :param limit:  Default 100; max 1000
         :type limit: int
 
         :returns: API response


### PR DESCRIPTION
I imagine it would be better to remove all limits, defaults, etc. from documentation here and refer the user to the official Binance API docs to avoid skew as the API changes underneath.