### PR TITLE
Patch historical klines to handle case where results exactly equal limit

### DIFF
--- a/PYPIREADME.rst
+++ b/PYPIREADME.rst
@@ -1,5 +1,5 @@
 ================================
-Welcome to python-binance v0.6.5
+Welcome to python-binance v0.6.6
 ================================
 
 .. image:: https://img.shields.io/pypi/v/python-binance.svg

--- a/PYPIREADME.rst
+++ b/PYPIREADME.rst
@@ -1,5 +1,5 @@
 ================================
-Welcome to python-binance v0.6.4
+Welcome to python-binance v0.6.5
 ================================
 
 .. image:: https://img.shields.io/pypi/v/python-binance.svg

--- a/PYPIREADME.rst
+++ b/PYPIREADME.rst
@@ -1,5 +1,5 @@
 ================================
-Welcome to python-binance v0.6.3
+Welcome to python-binance v0.6.4
 ================================
 
 .. image:: https://img.shields.io/pypi/v/python-binance.svg

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ================================
-Welcome to python-binance v0.6.5
+Welcome to python-binance v0.6.6
 ================================
 
 .. image:: https://img.shields.io/pypi/v/python-binance.svg

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ================================
-Welcome to python-binance v0.6.4
+Welcome to python-binance v0.6.5
 ================================
 
 .. image:: https://img.shields.io/pypi/v/python-binance.svg

--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,8 @@ or `Qryptos <https://accounts.qryptos.com/sign-up?affiliate=PAxghztC67615>`_ che
 
 If you use `Kucoin <https://www.kucoin.com/#/?r=E42cWB>`_ check out my `python-kucoin <https://github.com/sammchardy/python-kucoin>`_ library.
 
+If you use `Allcoin <https://www.allcoin.com/Account/RegisterByPhoneNumber/?InviteCode=MTQ2OTk4MDgwMDEzNDczMQ==>`_ check out my `python-allucoin <https://github.com/sammchardy/python-allcoin>`_ library.
+
 If you use `IDEX <https://idex.market>`_ check out my `python-idex <https://github.com/sammchardy/python-idex>`_ library.
 
 If you use `BigONE <https://big.one>`_ check out my `python-bigone <https://github.com/sammchardy/python-bigone>`_ library.

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ================================
-Welcome to python-binance v0.6.3
+Welcome to python-binance v0.6.4
 ================================
 
 .. image:: https://img.shields.io/pypi/v/python-binance.svg

--- a/binance/client.py
+++ b/binance/client.py
@@ -742,6 +742,11 @@ class Client(object):
                 symbol_existed = True
 
             if symbol_existed:
+
+                # handle the case where exactly the limit amount of data was returned last loop
+                if not len(temp_data):
+                    break
+
                 # append this loops data to our output data
                 output_data += temp_data
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v0.6.4 - 2018-02-09
+^^^^^^^^^^^^^^^^^^^
+
+**Added**
+
+- system status endpoint `get_system_status`
+
 v0.6.3 - 2018-01-29
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v0.6.6 - 2018-02-17
+^^^^^^^^^^^^^^^^^^^
+
+**Fixed**
+
+- User stream websocket keep alive strategy updated
+
 v0.6.5 - 2018-02-13
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v0.6.5 - 2018-02-13
+^^^^^^^^^^^^^^^^^^^
+
+**Fixed**
+
+- `get_historical_klines` response for month interval
+
 v0.6.4 - 2018-02-09
 ^^^^^^^^^^^^^^^^^^^
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='python-binance',
-    version='0.6.3',
+    version='0.6.4',
     packages=['binance'],
     description='Binance REST API python implementation',
     url='https://github.com/sammchardy/python-binance',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='python-binance',
-    version='0.6.5',
+    version='0.6.6',
     packages=['binance'],
     description='Binance REST API python implementation',
     url='https://github.com/sammchardy/python-binance',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='python-binance',
-    version='0.6.4',
+    version='0.6.5',
     packages=['binance'],
     description='Binance REST API python implementation',
     url='https://github.com/sammchardy/python-binance',


### PR DESCRIPTION
Hi Sam,

It was [reported](https://github.com/sammchardy/python-binance/issues/183) that historical klines will crash when the number of data points returned matches the limit exactly.

Kline loop was only exiting when the data return was < limit so this makes sense.
It caused the loop to run once more, retrieve an empty kline dataset, then fall over when trying to access the [-1] index of the empty dataset.

I added a test that will also break the loop if an empty kline dataset is returned (after the symbol_existed).

Pretty sure this would have taken you about as long to write yourself than handle this PR but I'm new to github and fancied the chance to try this out.

Thanks for the library, it helped me out a lot getting off the ground trading,
Michael