### PR TITLE
Fix time interval bug aggregate_trades_iter

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -617,14 +617,14 @@ class Client(object):
             if start_str is None:
                 trades = self.get_aggregate_trades(symbol=symbol, fromId=0)
             else:
-                # It doesn't matter what the end time is, as long as it's less
-                # than a day and the result set contains at least one trade.
-                # A half a day should be fine.
+                # The difference between startTime and endTime should be less
+                # or equal than an hour and the result set should contain at
+                # least one trade.
                 start_ts = date_to_milliseconds(start_str)
                 trades = self.get_aggregate_trades(
                     symbol=symbol,
                     startTime=start_ts,
-                    endTime=start_ts + (1000 * 86400 / 2))
+                    endTime=start_ts + (60 * 60 * 1000))
             for t in trades:
                 yield t
             last_id = trades[-1][self.AGG_ID]


### PR DESCRIPTION
With the previous implementation, using start_str='30 minutes ago UTC' gives error (Illegal characters found in parameter 'endTime'; legal range is '^[0-9]{1,20}$') because the time was / by 2 and then not casted to int resulting in a float value. When this was fixed I noticed that the end time interval does matter, as the Binance API is requesting one hour intervals, so half day does not work anymore (binance.exceptions.BinanceAPIException: APIError(code=-1127): More than 1 hours between startTime and endTime). 

Error mentioned in #215 