### PR TITLE
Remove unused LISTENKEY_NOT_EXIST

### DIFF
--- a/binance/exceptions.py
+++ b/binance/exceptions.py
@@ -3,8 +3,6 @@
 
 class BinanceAPIException(Exception):
 
-    LISTENKEY_NOT_EXIST = '-1125'
-
     def __init__(self, response):
         self.code = 0
         try:


### PR DESCRIPTION
`LISTENKEY_NOT_EXIST` was introduced by Sam McHardy in commit 3508a647. The mechanism which it was used in has since been removed, leaving `LISTENKEY_NOT_EXIST` unused.