### PR TITLE
bug fix in date_to_milliseconds, which getting wrong date(not UTC-0) …

### DIFF
--- a/binance/helpers.py
+++ b/binance/helpers.py
@@ -19,7 +19,7 @@ def date_to_milliseconds(date_str):
     # get epoch value in UTC
     epoch = datetime.utcfromtimestamp(0).replace(tzinfo=pytz.utc)
     # parse our date string
-    d = dateparser.parse(date_str)
+    d = dateparser.parse(date_str, settings={'TO_TIMEZONE': 'UTC'})
     # if the date is not timezone aware apply UTC timezone
     if d.tzinfo is None or d.tzinfo.utcoffset(d) is None:
         d = d.replace(tzinfo=pytz.utc)


### PR DESCRIPTION
Description of problem
I working with data from binance in `utc-0`. But, when i try to get some data using `get_historical_klines`, i pass `start_str` and `end_str`.
And inside of method date string is convert to milliseconds through `date_to_milliseconds`. And when i try to pass date in timestamp, like this:
`klines = client.get_historical_klines("ETHBTC", Client.KLINE_INTERVAL_30MINUTE, "1 Dec, 2017", "1527300000")`
where `1527300000` it is '2018-05-26 02:00' in seconds
i getting wrong set of data, where get_historical_klines getting data filtering by my timezone. This bug  is only reproduced when using timestamp.
**BUG  FIXED**
dateparser.parse(date_str, settings={'TO_TIMEZONE': 'UTC'})