### PR TITLE
Port the get_all_tickers and get_orderbook_tickers to the v3 API

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -404,7 +404,7 @@ class Client(object):
         :raises: BinanceRequestException, BinanceAPIException
 
         """
-        return self._get('ticker/allPrices')
+        return self._get('ticker/price', version='v3')
 
     def get_orderbook_tickers(self):
         """Best price/qty on the order book for all symbols.
@@ -435,7 +435,7 @@ class Client(object):
         :raises: BinanceRequestException, BinanceAPIException
 
         """
-        return self._get('ticker/allBookTickers')
+        return self._get('ticker/bookTicker', version='v3')
 
     def get_order_book(self, **params):
         """Get the Order Book for the market


### PR DESCRIPTION
It seems that the `get_all_tickers` and `get_orderbook_tickers` calls use the old `v1` API, which is not documented anymore. This patch ports them to use `/api/v3/ticker/price` and `/api/v3/ticker/bookTicker` respectively.

https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#symbol-price-ticker
https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#symbol-order-book-ticker