### PR TITLE
Added support for stripping None-valued parameters

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -10,7 +10,6 @@ from .exceptions import BinanceAPIException, BinanceRequestException, BinanceWit
 
 
 class Client(object):
-
     API_URL = 'https://api.binance.com/api'
     WITHDRAW_API_URL = 'https://api.binance.com/wapi'
     MARGIN_API_URL = 'https://api.binance.com/sapi'
@@ -98,9 +97,11 @@ class Client(object):
     def _init_session(self):
 
         session = requests.session()
-        session.headers.update({'Accept': 'application/json',
-                                'User-Agent': 'binance/python',
-                                'X-MBX-APIKEY': self.API_KEY})
+        session.headers.update({
+            'Accept': 'application/json',
+            'User-Agent': 'binance/python',
+            'X-MBX-APIKEY': self.API_KEY
+            })
         return session
 
     def _create_api_uri(self, path, signed=True, version=PUBLIC_API_VERSION):
@@ -160,7 +161,7 @@ class Client(object):
             if 'requests_params' in kwargs['data']:
                 # merge requests params into kwargs
                 kwargs.update(kwargs['data']['requests_params'])
-                del(kwargs['data']['requests_params'])
+                del (kwargs['data']['requests_params'])
 
         if signed:
             # generate signature
@@ -172,14 +173,14 @@ class Client(object):
             # sort post params
             kwargs['data'] = self._order_params(kwargs['data'])
             # Remove any arguments with values of None.
-            null_args = [i for i,(key,value) in enumerate(kwargs['data']) if value is None]
+            null_args = [i for i, (key, value) in enumerate(kwargs['data']) if value is None]
             for i in reversed(null_args):
                 del kwargs['data'][i]
 
         # if get request assign data array to params value for requests lib
         if data and (method == 'get' or force_params):
             kwargs['params'] = '&'.join('%s=%s' % (data[0], data[1]) for data in kwargs['data'])
-            del(kwargs['data'])
+            del (kwargs['data'])
 
         response = getattr(self.session, method)(uri, **kwargs)
         return self._handle_response(response)
@@ -555,7 +556,8 @@ class Client(object):
         """Get compressed, aggregate trades. Trades that fill at the time,
         from the same order, with the same price will have the quantity aggregated.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#compressedaggregate-trades-list
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#compressedaggregate
+        -trades-list
 
         :param symbol: required
         :type symbol: str
@@ -614,7 +616,8 @@ class Client(object):
         return the first trade occurring later than this time.
         :type start_str: str|int
         :param last_id: aggregate trade ID of the last known aggregate trade.
-        Not a regular trade ID. See https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#compressedaggregate-trades-list.
+        Not a regular trade ID. See https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest
+        -api.md#compressedaggregate-trades-list.
 
         :returns: an iterator of JSON objects, one per trade. The format of
         each object is identical to Client.aggregate_trades().
@@ -735,7 +738,7 @@ class Client(object):
             limit=1,
             startTime=0,
             endTime=None
-        )
+            )
         return kline[0][0]
 
     def get_historical_klines(self, symbol, interval, start_str, end_str=None,
@@ -752,7 +755,8 @@ class Client(object):
         :type interval: str
         :param start_str: Start date string in UTC format or timestamp in milliseconds
         :type start_str: str|int
-        :param end_str: optional - end date string in UTC format or timestamp in milliseconds (default will fetch everything up to now)
+        :param end_str: optional - end date string in UTC format or timestamp in milliseconds (default will fetch
+        everything up to now)
         :type end_str: str|int
         :param limit: Default 500; max 1000.
         :type limit: int
@@ -796,7 +800,7 @@ class Client(object):
                 limit=limit,
                 startTime=start_ts,
                 endTime=end_ts
-            )
+                )
 
             # handle the case where exactly the limit amount of data was returned last loop
             if not len(temp_data):
@@ -836,7 +840,8 @@ class Client(object):
         :type interval: str
         :param start_str: Start date string in UTC format or timestamp in milliseconds
         :type start_str: str|int
-        :param end_str: optional - end date string in UTC format or timestamp in milliseconds (default will fetch everything up to now)
+        :param end_str: optional - end date string in UTC format or timestamp in milliseconds (default will fetch
+        everything up to now)
         :type end_str: str|int
 
         :return: generator of OHLCV values
@@ -876,7 +881,7 @@ class Client(object):
                 limit=limit,
                 startTime=start_ts,
                 endTime=end_ts
-            )
+                )
 
             # handle the case where exactly the limit amount of data was returned last loop
             if not len(output_data):
@@ -905,7 +910,8 @@ class Client(object):
     def get_ticker(self, **params):
         """24 hour price change statistics.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#24hr-ticker-price-change-statistics
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#24hr-ticker-price
+        -change-statistics
 
         :param symbol:
         :type symbol: str
@@ -966,7 +972,8 @@ class Client(object):
     def get_symbol_ticker(self, **params):
         """Latest price for a symbol or symbols.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#24hr-ticker-price-change-statistics
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#24hr-ticker-price
+        -change-statistics
 
         :param symbol:
         :type symbol: str
@@ -1157,7 +1164,9 @@ class Client(object):
                 ]
             }
 
-        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException, BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException, BinanceOrderInactiveSymbolException
+        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException,
+        BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException,
+        BinanceOrderInactiveSymbolException
 
         """
         return self._post('order', True, data=params)
@@ -1190,13 +1199,15 @@ class Client(object):
 
         See order endpoint for full response options
 
-        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException, BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException, BinanceOrderInactiveSymbolException
+        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException,
+        BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException,
+        BinanceOrderInactiveSymbolException
 
         """
         params.update({
             'type': self.ORDER_TYPE_LIMIT,
             'timeInForce': timeInForce
-        })
+            })
         return self.create_order(**params)
 
     def order_limit_buy(self, timeInForce=TIME_IN_FORCE_GTC, **params):
@@ -1227,12 +1238,14 @@ class Client(object):
 
         See order endpoint for full response options
 
-        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException, BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException, BinanceOrderInactiveSymbolException
+        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException,
+        BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException,
+        BinanceOrderInactiveSymbolException
 
         """
         params.update({
             'side': self.SIDE_BUY,
-        })
+            })
         return self.order_limit(timeInForce=timeInForce, **params)
 
     def order_limit_sell(self, timeInForce=TIME_IN_FORCE_GTC, **params):
@@ -1261,12 +1274,14 @@ class Client(object):
 
         See order endpoint for full response options
 
-        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException, BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException, BinanceOrderInactiveSymbolException
+        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException,
+        BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException,
+        BinanceOrderInactiveSymbolException
 
         """
         params.update({
             'side': self.SIDE_SELL
-        })
+            })
         return self.order_limit(timeInForce=timeInForce, **params)
 
     def order_market(self, **params):
@@ -1289,12 +1304,14 @@ class Client(object):
 
         See order endpoint for full response options
 
-        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException, BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException, BinanceOrderInactiveSymbolException
+        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException,
+        BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException,
+        BinanceOrderInactiveSymbolException
 
         """
         params.update({
             'type': self.ORDER_TYPE_MARKET
-        })
+            })
         return self.create_order(**params)
 
     def order_market_buy(self, **params):
@@ -1315,12 +1332,14 @@ class Client(object):
 
         See order endpoint for full response options
 
-        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException, BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException, BinanceOrderInactiveSymbolException
+        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException,
+        BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException,
+        BinanceOrderInactiveSymbolException
 
         """
         params.update({
             'side': self.SIDE_BUY
-        })
+            })
         return self.order_market(**params)
 
     def order_market_sell(self, **params):
@@ -1341,16 +1360,19 @@ class Client(object):
 
         See order endpoint for full response options
 
-        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException, BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException, BinanceOrderInactiveSymbolException
+        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException,
+        BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException,
+        BinanceOrderInactiveSymbolException
 
         """
         params.update({
             'side': self.SIDE_SELL
-        })
+            })
         return self.order_market(**params)
 
     def create_test_order(self, **params):
-        """Test new order creation and signature/recvWindow long. Creates and validates a new order but does not send it into the matching engine.
+        """Test new order creation and signature/recvWindow long. Creates and validates a new order but does not send
+        it into the matching engine.
 
         https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#test-new-order-trade
 
@@ -1381,7 +1403,9 @@ class Client(object):
 
             {}
 
-        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException, BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException, BinanceOrderInactiveSymbolException
+        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException,
+        BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException,
+        BinanceOrderInactiveSymbolException
 
 
         """
@@ -1502,7 +1526,8 @@ class Client(object):
     def get_open_orders(self, **params):
         """Get all open orders on a symbol.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#current-open-orders-user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#current-open-orders
+        -user_data
 
         :param symbol: optional
         :type symbol: str
@@ -1540,7 +1565,8 @@ class Client(object):
     def get_account(self, **params):
         """Get current account information.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#account-information-user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#account-information
+        -user_data
 
         :param recvWindow: the number of milliseconds the request is valid for
         :type recvWindow: int
@@ -1579,7 +1605,8 @@ class Client(object):
     def get_asset_balance(self, asset, **params):
         """Get current asset balance.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#account-information-user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#account-information
+        -user_data
 
         :param asset: required
         :type asset: str
@@ -1610,7 +1637,8 @@ class Client(object):
     def get_my_trades(self, **params):
         """Get trades for a specific symbol.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#account-trade-list-user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#account-trade-list
+        -user_data
 
         :param symbol: required
         :type symbol: str
@@ -1775,7 +1803,8 @@ class Client(object):
     def transfer_dust(self, **params):
         """Convert dust assets to BNB.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/9dbe0e961b80557bb19708a707c7fad08842b28e/wapi-api.md#dust-transfer-user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/9dbe0e961b80557bb19708a707c7fad08842b28e
+        /wapi-api.md#dust-transfer-user_data
 
         :param asset: The asset being converted. e.g: 'ONE'
         :type asset: str
@@ -1813,7 +1842,8 @@ class Client(object):
     def get_asset_dividend_history(self, **params):
         """Query asset dividend record.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/9dbe0e961b80557bb19708a707c7fad08842b28e/wapi-api.md#asset-dividend-record-user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/9dbe0e961b80557bb19708a707c7fad08842b28e
+        /wapi-api.md#asset-dividend-record-user_data
 
         :param asset: optional
         :type asset: str
@@ -2023,7 +2053,8 @@ class Client(object):
 
         :param asset: optional
         :type asset: str
-        :type status: 0(0:Email Sent,1:Cancelled 2:Awaiting Approval 3:Rejected 4:Processing 5:Failure 6Completed) optional
+        :type status: 0(0:Email Sent,1:Cancelled 2:Awaiting Approval 3:Rejected 4:Processing 5:Failure 6Completed)
+        optional
         :type status: int
         :param startTime: optional
         :type startTime: long
@@ -2097,7 +2128,8 @@ class Client(object):
 
         Can be used to keep the user stream alive.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#start-user-data-stream-user_stream
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#start-user-data-stream
+        -user_stream
 
         :returns: API response
 
@@ -2116,7 +2148,8 @@ class Client(object):
     def stream_keepalive(self, listenKey):
         """PING a user data stream to prevent a time out.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#keepalive-user-data-stream-user_stream
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#keepalive-user-data
+        -stream-user_stream
 
         :param listenKey: required
         :type listenKey: str
@@ -2132,13 +2165,14 @@ class Client(object):
         """
         params = {
             'listenKey': listenKey
-        }
+            }
         return self._put('userDataStream', False, data=params)
 
     def stream_close(self, listenKey):
         """Close out a user data stream.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#close-user-data-stream-user_stream
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#close-user-data-stream
+        -user_stream
 
         :param listenKey: required
         :type listenKey: str
@@ -2154,7 +2188,7 @@ class Client(object):
         """
         params = {
             'listenKey': listenKey
-        }
+            }
         return self._delete('userDataStream', False, data=params)
 
     # Margin Trading Endpoints
@@ -2162,7 +2196,8 @@ class Client(object):
     def get_margin_account(self, **params):
         """Query margin account details
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-account-details-user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-account
+        -details-user_data
 
         :returns: API response
 
@@ -2220,7 +2255,8 @@ class Client(object):
     def get_margin_asset(self, **params):
         """Query margin asset
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-asset-market_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-asset
+        -market_data
 
         :param asset: name of the asset
         :type asset: str
@@ -2250,7 +2286,8 @@ class Client(object):
     def get_margin_symbol(self, **params):
         """Query margin symbol info
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-pair-market_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-pair
+        -market_data
 
         :param symbol: name of the symbol pair
         :type symbol: str
@@ -2282,7 +2319,8 @@ class Client(object):
     def get_margin_price_index(self, **params):
         """Query margin priceIndex
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-priceindex-market_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin
+        -priceindex-market_data
 
         :param symbol: name of the symbol pair
         :type symbol: str
@@ -2309,7 +2347,8 @@ class Client(object):
     def transfer_margin_to_spot(self, **params):
         """Execute transfer between margin account and spot account.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-transfer-margin
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account
+        -transfer-margin
 
         :param asset: name of the asset
         :type asset: str
@@ -2339,7 +2378,8 @@ class Client(object):
     def transfer_spot_to_margin(self, **params):
         """Execute transfer between spot account and margin account.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-transfer-margin
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account
+        -transfer-margin
 
         :param asset: name of the asset
         :type asset: str
@@ -2369,7 +2409,8 @@ class Client(object):
     def create_margin_loan(self, **params):
         """Apply for a loan.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-borrow-margin
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-borrow
+        -margin
 
         :param asset: name of the asset
         :type asset: str
@@ -2398,7 +2439,8 @@ class Client(object):
     def repay_margin_loan(self, **params):
         """Repay loan for margin account.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-repay-margin
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-repay
+        -margin
 
         :param asset: name of the asset
         :type asset: str
@@ -2427,7 +2469,8 @@ class Client(object):
     def create_margin_order(self, **params):
         """Post a new order for margin account.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-new-order-trade
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-new
+        -order-trade
 
         :param symbol: required
         :type symbol: str
@@ -2548,7 +2591,8 @@ class Client(object):
 
         Either orderId or origClientOrderId must be sent.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-cancel-order-trade
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-cancel
+        -order-trade
 
         :param symbol: required
         :type symbol: str
@@ -2589,7 +2633,8 @@ class Client(object):
 
         txId or startTime must be sent. txId takes precedence.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-cancel-order-trade
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-cancel
+        -order-trade
 
         :param asset: required
         :type asset: str
@@ -2614,7 +2659,8 @@ class Client(object):
                         "asset": "BNB",
                         "principal": "0.84624403",
                         "timestamp": 1555056425000,
-                        //one of PENDING (pending to execution), CONFIRMED (successfully loaned), FAILED (execution failed, nothing happened to your account);
+                        //one of PENDING (pending to execution), CONFIRMED (successfully loaned), FAILED (execution
+                        failed, nothing happened to your account);
                         "status": "CONFIRMED"
                     }
                 ],
@@ -2631,7 +2677,8 @@ class Client(object):
 
         txId or startTime must be sent. txId takes precedence.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-cancel-order-trade
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-cancel
+        -order-trade
 
         :param asset: required
         :type asset: str
@@ -2660,7 +2707,8 @@ class Client(object):
                         "interest": "0.01866667",
                         //Principal repaid
                         "principal": "13.98133333",
-                        //one of PENDING (pending to execution), CONFIRMED (successfully loaned), FAILED (execution failed, nothing happened to your account);
+                        //one of PENDING (pending to execution), CONFIRMED (successfully loaned), FAILED (execution
+                        failed, nothing happened to your account);
                         "status": "CONFIRMED",
                         "timestamp": 1563438204000,
                         "txId": 2970933056
@@ -2681,7 +2729,8 @@ class Client(object):
 
         For some historical orders cummulativeQuoteQty will be < 0, meaning the data is not available at this time.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-accounts-order-user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-accounts
+        -order-user_data
 
         :param symbol: required
         :type symbol: str
@@ -2726,7 +2775,8 @@ class Client(object):
         When all symbols are returned, the number of requests counted against the rate limiter is equal to the number
         of symbols currently trading on the exchange.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-accounts-open-order-user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-accounts
+        -open-order-user_data
 
         :param symbol: optional
         :type symbol: str
@@ -2768,7 +2818,8 @@ class Client(object):
 
         For some historical orders cummulativeQuoteQty will be < 0, meaning the data is not available at this time.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-accounts-open-order-user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-accounts
+        -open-order-user_data
 
         :param symbol: required
         :type symbol: str
@@ -2823,7 +2874,8 @@ class Client(object):
 
         If fromId is set, it will get orders >= that fromId. Otherwise most recent orders are returned.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-accounts-trade-list-user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-accounts
+        -trade-list-user_data
 
         :param symbol: required
         :type symbol: str
@@ -2877,7 +2929,8 @@ class Client(object):
     def get_max_margin_loan(self, **params):
         """Query max borrow amount for an asset
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-max-borrow-user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-max-borrow
+        -user_data
 
         :param asset: required
         :type asset: str
@@ -2898,7 +2951,8 @@ class Client(object):
     def get_max_margin_transfer(self, **params):
         """Query max transfer-out amount
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-max-transfer-out-amount-user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-max-transfer
+        -out-amount-user_data
 
         :param asset: required
         :type asset: str
@@ -2923,7 +2977,8 @@ class Client(object):
 
         Can be used to keep the user stream alive.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#start-user-data-stream-for-margin-account-user_stream
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#start-user-data
+        -stream-for-margin-account-user_stream
 
         :returns: API response
 
@@ -2942,7 +2997,8 @@ class Client(object):
     def margin_stream_keepalive(self, listenKey):
         """PING a margin data stream to prevent a time out.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#ping-user-data-stream-for-margin-account--user_stream
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#ping-user-data-stream
+        -for-margin-account--user_stream
 
         :param listenKey: required
         :type listenKey: str
@@ -2958,13 +3014,14 @@ class Client(object):
         """
         params = {
             'listenKey': listenKey
-        }
+            }
         return self._request_margin_api('put', 'userDataStream', signed=True, data=params)
 
     def margin_stream_close(self, listenKey):
         """Close out a margin data stream.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#delete-user-data-stream-for-margin-account--user_stream
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#delete-user-data
+        -stream-for-margin-account--user_stream
 
         :param listenKey: required
         :type listenKey: str
@@ -2980,7 +3037,7 @@ class Client(object):
         """
         params = {
             'listenKey': listenKey
-        }
+            }
         return self._request_margin_api('delete', 'userDataStream', signed=True, data=params)
 
     # Sub Accounts
@@ -2988,7 +3045,8 @@ class Client(object):
     def get_sub_account_list(self, **params):
         """Query Sub-account List.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/wapi-api.md#query-sub-account-listfor-master-account
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/wapi-api.md#query-sub-account
+        -listfor-master-account
 
         :param email: optional
         :type email: str
@@ -3038,7 +3096,8 @@ class Client(object):
     def get_sub_account_transfer_history(self, **params):
         """Query Sub-account Transfer History.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/wapi-api.md#query-sub-account-transfer-historyfor-master-account
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/wapi-api.md#query-sub-account
+        -transfer-historyfor-master-account
 
         :param email: required
         :type email: str
@@ -3085,7 +3144,8 @@ class Client(object):
     def create_sub_account_transfer(self, **params):
         """Execute sub-account transfer
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/9dbe0e961b80557bb19708a707c7fad08842b28e/wapi-api.md#sub-account-transferfor-master-account
+        https://github.com/binance-exchange/binance-official-api-docs/blob/9dbe0e961b80557bb19708a707c7fad08842b28e
+        /wapi-api.md#sub-account-transferfor-master-account
 
         :param fromEmail: required - Sender email
         :type fromEmail: str
@@ -3115,7 +3175,8 @@ class Client(object):
     def get_sub_account_assets(self, **params):
         """Fetch sub-account assets
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/9dbe0e961b80557bb19708a707c7fad08842b28e/wapi-api.md#query-sub-account-assetsfor-master-account
+        https://github.com/binance-exchange/binance-official-api-docs/blob/9dbe0e961b80557bb19708a707c7fad08842b28e
+        /wapi-api.md#query-sub-account-assetsfor-master-account
 
         :param email: required
         :type email: str

--- a/binance/client.py
+++ b/binance/client.py
@@ -10,6 +10,7 @@ from .exceptions import BinanceAPIException, BinanceRequestException, BinanceWit
 
 
 class Client(object):
+
     API_URL = 'https://api.binance.com/api'
     WITHDRAW_API_URL = 'https://api.binance.com/wapi'
     MARGIN_API_URL = 'https://api.binance.com/sapi'
@@ -97,11 +98,9 @@ class Client(object):
     def _init_session(self):
 
         session = requests.session()
-        session.headers.update({
-            'Accept': 'application/json',
-            'User-Agent': 'binance/python',
-            'X-MBX-APIKEY': self.API_KEY
-            })
+        session.headers.update({'Accept': 'application/json',
+                                'User-Agent': 'binance/python',
+                                'X-MBX-APIKEY': self.API_KEY})
         return session
 
     def _create_api_uri(self, path, signed=True, version=PUBLIC_API_VERSION):
@@ -161,7 +160,7 @@ class Client(object):
             if 'requests_params' in kwargs['data']:
                 # merge requests params into kwargs
                 kwargs.update(kwargs['data']['requests_params'])
-                del (kwargs['data']['requests_params'])
+                del(kwargs['data']['requests_params'])
 
         if signed:
             # generate signature
@@ -180,7 +179,7 @@ class Client(object):
         # if get request assign data array to params value for requests lib
         if data and (method == 'get' or force_params):
             kwargs['params'] = '&'.join('%s=%s' % (data[0], data[1]) for data in kwargs['data'])
-            del (kwargs['data'])
+            del(kwargs['data'])
 
         response = getattr(self.session, method)(uri, **kwargs)
         return self._handle_response(response)
@@ -556,8 +555,7 @@ class Client(object):
         """Get compressed, aggregate trades. Trades that fill at the time,
         from the same order, with the same price will have the quantity aggregated.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#compressedaggregate
-        -trades-list
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#compressedaggregate-trades-list
 
         :param symbol: required
         :type symbol: str
@@ -616,8 +614,7 @@ class Client(object):
         return the first trade occurring later than this time.
         :type start_str: str|int
         :param last_id: aggregate trade ID of the last known aggregate trade.
-        Not a regular trade ID. See https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest
-        -api.md#compressedaggregate-trades-list.
+        Not a regular trade ID. See https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#compressedaggregate-trades-list.
 
         :returns: an iterator of JSON objects, one per trade. The format of
         each object is identical to Client.aggregate_trades().
@@ -738,7 +735,7 @@ class Client(object):
             limit=1,
             startTime=0,
             endTime=None
-            )
+        )
         return kline[0][0]
 
     def get_historical_klines(self, symbol, interval, start_str, end_str=None,
@@ -755,8 +752,7 @@ class Client(object):
         :type interval: str
         :param start_str: Start date string in UTC format or timestamp in milliseconds
         :type start_str: str|int
-        :param end_str: optional - end date string in UTC format or timestamp in milliseconds (default will fetch
-        everything up to now)
+        :param end_str: optional - end date string in UTC format or timestamp in milliseconds (default will fetch everything up to now)
         :type end_str: str|int
         :param limit: Default 500; max 1000.
         :type limit: int
@@ -800,7 +796,7 @@ class Client(object):
                 limit=limit,
                 startTime=start_ts,
                 endTime=end_ts
-                )
+            )
 
             # handle the case where exactly the limit amount of data was returned last loop
             if not len(temp_data):
@@ -840,8 +836,7 @@ class Client(object):
         :type interval: str
         :param start_str: Start date string in UTC format or timestamp in milliseconds
         :type start_str: str|int
-        :param end_str: optional - end date string in UTC format or timestamp in milliseconds (default will fetch
-        everything up to now)
+        :param end_str: optional - end date string in UTC format or timestamp in milliseconds (default will fetch everything up to now)
         :type end_str: str|int
 
         :return: generator of OHLCV values
@@ -881,7 +876,7 @@ class Client(object):
                 limit=limit,
                 startTime=start_ts,
                 endTime=end_ts
-                )
+            )
 
             # handle the case where exactly the limit amount of data was returned last loop
             if not len(output_data):
@@ -910,8 +905,7 @@ class Client(object):
     def get_ticker(self, **params):
         """24 hour price change statistics.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#24hr-ticker-price
-        -change-statistics
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#24hr-ticker-price-change-statistics
 
         :param symbol:
         :type symbol: str
@@ -972,8 +966,7 @@ class Client(object):
     def get_symbol_ticker(self, **params):
         """Latest price for a symbol or symbols.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#24hr-ticker-price
-        -change-statistics
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#24hr-ticker-price-change-statistics
 
         :param symbol:
         :type symbol: str
@@ -1164,9 +1157,7 @@ class Client(object):
                 ]
             }
 
-        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException,
-        BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException,
-        BinanceOrderInactiveSymbolException
+        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException, BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException, BinanceOrderInactiveSymbolException
 
         """
         return self._post('order', True, data=params)
@@ -1199,15 +1190,13 @@ class Client(object):
 
         See order endpoint for full response options
 
-        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException,
-        BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException,
-        BinanceOrderInactiveSymbolException
+        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException, BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException, BinanceOrderInactiveSymbolException
 
         """
         params.update({
             'type': self.ORDER_TYPE_LIMIT,
             'timeInForce': timeInForce
-            })
+        })
         return self.create_order(**params)
 
     def order_limit_buy(self, timeInForce=TIME_IN_FORCE_GTC, **params):
@@ -1238,14 +1227,12 @@ class Client(object):
 
         See order endpoint for full response options
 
-        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException,
-        BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException,
-        BinanceOrderInactiveSymbolException
+        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException, BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException, BinanceOrderInactiveSymbolException
 
         """
         params.update({
             'side': self.SIDE_BUY,
-            })
+        })
         return self.order_limit(timeInForce=timeInForce, **params)
 
     def order_limit_sell(self, timeInForce=TIME_IN_FORCE_GTC, **params):
@@ -1274,14 +1261,12 @@ class Client(object):
 
         See order endpoint for full response options
 
-        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException,
-        BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException,
-        BinanceOrderInactiveSymbolException
+        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException, BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException, BinanceOrderInactiveSymbolException
 
         """
         params.update({
             'side': self.SIDE_SELL
-            })
+        })
         return self.order_limit(timeInForce=timeInForce, **params)
 
     def order_market(self, **params):
@@ -1304,14 +1289,12 @@ class Client(object):
 
         See order endpoint for full response options
 
-        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException,
-        BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException,
-        BinanceOrderInactiveSymbolException
+        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException, BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException, BinanceOrderInactiveSymbolException
 
         """
         params.update({
             'type': self.ORDER_TYPE_MARKET
-            })
+        })
         return self.create_order(**params)
 
     def order_market_buy(self, **params):
@@ -1332,14 +1315,12 @@ class Client(object):
 
         See order endpoint for full response options
 
-        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException,
-        BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException,
-        BinanceOrderInactiveSymbolException
+        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException, BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException, BinanceOrderInactiveSymbolException
 
         """
         params.update({
             'side': self.SIDE_BUY
-            })
+        })
         return self.order_market(**params)
 
     def order_market_sell(self, **params):
@@ -1360,19 +1341,16 @@ class Client(object):
 
         See order endpoint for full response options
 
-        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException,
-        BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException,
-        BinanceOrderInactiveSymbolException
+        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException, BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException, BinanceOrderInactiveSymbolException
 
         """
         params.update({
             'side': self.SIDE_SELL
-            })
+        })
         return self.order_market(**params)
 
     def create_test_order(self, **params):
-        """Test new order creation and signature/recvWindow long. Creates and validates a new order but does not send
-        it into the matching engine.
+        """Test new order creation and signature/recvWindow long. Creates and validates a new order but does not send it into the matching engine.
 
         https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#test-new-order-trade
 
@@ -1403,9 +1381,7 @@ class Client(object):
 
             {}
 
-        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException,
-        BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException,
-        BinanceOrderInactiveSymbolException
+        :raises: BinanceRequestException, BinanceAPIException, BinanceOrderException, BinanceOrderMinAmountException, BinanceOrderMinPriceException, BinanceOrderMinTotalException, BinanceOrderUnknownSymbolException, BinanceOrderInactiveSymbolException
 
 
         """
@@ -1526,8 +1502,7 @@ class Client(object):
     def get_open_orders(self, **params):
         """Get all open orders on a symbol.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#current-open-orders
-        -user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#current-open-orders-user_data
 
         :param symbol: optional
         :type symbol: str
@@ -1565,8 +1540,7 @@ class Client(object):
     def get_account(self, **params):
         """Get current account information.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#account-information
-        -user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#account-information-user_data
 
         :param recvWindow: the number of milliseconds the request is valid for
         :type recvWindow: int
@@ -1605,8 +1579,7 @@ class Client(object):
     def get_asset_balance(self, asset, **params):
         """Get current asset balance.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#account-information
-        -user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#account-information-user_data
 
         :param asset: required
         :type asset: str
@@ -1637,8 +1610,7 @@ class Client(object):
     def get_my_trades(self, **params):
         """Get trades for a specific symbol.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#account-trade-list
-        -user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#account-trade-list-user_data
 
         :param symbol: required
         :type symbol: str
@@ -1803,8 +1775,7 @@ class Client(object):
     def transfer_dust(self, **params):
         """Convert dust assets to BNB.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/9dbe0e961b80557bb19708a707c7fad08842b28e
-        /wapi-api.md#dust-transfer-user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/9dbe0e961b80557bb19708a707c7fad08842b28e/wapi-api.md#dust-transfer-user_data
 
         :param asset: The asset being converted. e.g: 'ONE'
         :type asset: str
@@ -1842,8 +1813,7 @@ class Client(object):
     def get_asset_dividend_history(self, **params):
         """Query asset dividend record.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/9dbe0e961b80557bb19708a707c7fad08842b28e
-        /wapi-api.md#asset-dividend-record-user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/9dbe0e961b80557bb19708a707c7fad08842b28e/wapi-api.md#asset-dividend-record-user_data
 
         :param asset: optional
         :type asset: str
@@ -2053,8 +2023,7 @@ class Client(object):
 
         :param asset: optional
         :type asset: str
-        :type status: 0(0:Email Sent,1:Cancelled 2:Awaiting Approval 3:Rejected 4:Processing 5:Failure 6Completed)
-        optional
+        :type status: 0(0:Email Sent,1:Cancelled 2:Awaiting Approval 3:Rejected 4:Processing 5:Failure 6Completed) optional
         :type status: int
         :param startTime: optional
         :type startTime: long
@@ -2128,8 +2097,7 @@ class Client(object):
 
         Can be used to keep the user stream alive.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#start-user-data-stream
-        -user_stream
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#start-user-data-stream-user_stream
 
         :returns: API response
 
@@ -2148,8 +2116,7 @@ class Client(object):
     def stream_keepalive(self, listenKey):
         """PING a user data stream to prevent a time out.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#keepalive-user-data
-        -stream-user_stream
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#keepalive-user-data-stream-user_stream
 
         :param listenKey: required
         :type listenKey: str
@@ -2165,14 +2132,13 @@ class Client(object):
         """
         params = {
             'listenKey': listenKey
-            }
+        }
         return self._put('userDataStream', False, data=params)
 
     def stream_close(self, listenKey):
         """Close out a user data stream.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#close-user-data-stream
-        -user_stream
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#close-user-data-stream-user_stream
 
         :param listenKey: required
         :type listenKey: str
@@ -2188,7 +2154,7 @@ class Client(object):
         """
         params = {
             'listenKey': listenKey
-            }
+        }
         return self._delete('userDataStream', False, data=params)
 
     # Margin Trading Endpoints
@@ -2196,8 +2162,7 @@ class Client(object):
     def get_margin_account(self, **params):
         """Query margin account details
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-account
-        -details-user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-account-details-user_data
 
         :returns: API response
 
@@ -2255,8 +2220,7 @@ class Client(object):
     def get_margin_asset(self, **params):
         """Query margin asset
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-asset
-        -market_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-asset-market_data
 
         :param asset: name of the asset
         :type asset: str
@@ -2286,8 +2250,7 @@ class Client(object):
     def get_margin_symbol(self, **params):
         """Query margin symbol info
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-pair
-        -market_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-pair-market_data
 
         :param symbol: name of the symbol pair
         :type symbol: str
@@ -2319,8 +2282,7 @@ class Client(object):
     def get_margin_price_index(self, **params):
         """Query margin priceIndex
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin
-        -priceindex-market_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-priceindex-market_data
 
         :param symbol: name of the symbol pair
         :type symbol: str
@@ -2347,8 +2309,7 @@ class Client(object):
     def transfer_margin_to_spot(self, **params):
         """Execute transfer between margin account and spot account.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account
-        -transfer-margin
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-transfer-margin
 
         :param asset: name of the asset
         :type asset: str
@@ -2378,8 +2339,7 @@ class Client(object):
     def transfer_spot_to_margin(self, **params):
         """Execute transfer between spot account and margin account.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account
-        -transfer-margin
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-transfer-margin
 
         :param asset: name of the asset
         :type asset: str
@@ -2409,8 +2369,7 @@ class Client(object):
     def create_margin_loan(self, **params):
         """Apply for a loan.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-borrow
-        -margin
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-borrow-margin
 
         :param asset: name of the asset
         :type asset: str
@@ -2439,8 +2398,7 @@ class Client(object):
     def repay_margin_loan(self, **params):
         """Repay loan for margin account.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-repay
-        -margin
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-repay-margin
 
         :param asset: name of the asset
         :type asset: str
@@ -2469,8 +2427,7 @@ class Client(object):
     def create_margin_order(self, **params):
         """Post a new order for margin account.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-new
-        -order-trade
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-new-order-trade
 
         :param symbol: required
         :type symbol: str
@@ -2591,8 +2548,7 @@ class Client(object):
 
         Either orderId or origClientOrderId must be sent.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-cancel
-        -order-trade
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-cancel-order-trade
 
         :param symbol: required
         :type symbol: str
@@ -2633,8 +2589,7 @@ class Client(object):
 
         txId or startTime must be sent. txId takes precedence.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-cancel
-        -order-trade
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-cancel-order-trade
 
         :param asset: required
         :type asset: str
@@ -2659,8 +2614,7 @@ class Client(object):
                         "asset": "BNB",
                         "principal": "0.84624403",
                         "timestamp": 1555056425000,
-                        //one of PENDING (pending to execution), CONFIRMED (successfully loaned), FAILED (execution
-                        failed, nothing happened to your account);
+                        //one of PENDING (pending to execution), CONFIRMED (successfully loaned), FAILED (execution failed, nothing happened to your account);
                         "status": "CONFIRMED"
                     }
                 ],
@@ -2677,8 +2631,7 @@ class Client(object):
 
         txId or startTime must be sent. txId takes precedence.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-cancel
-        -order-trade
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#margin-account-cancel-order-trade
 
         :param asset: required
         :type asset: str
@@ -2707,8 +2660,7 @@ class Client(object):
                         "interest": "0.01866667",
                         //Principal repaid
                         "principal": "13.98133333",
-                        //one of PENDING (pending to execution), CONFIRMED (successfully loaned), FAILED (execution
-                        failed, nothing happened to your account);
+                        //one of PENDING (pending to execution), CONFIRMED (successfully loaned), FAILED (execution failed, nothing happened to your account);
                         "status": "CONFIRMED",
                         "timestamp": 1563438204000,
                         "txId": 2970933056
@@ -2729,8 +2681,7 @@ class Client(object):
 
         For some historical orders cummulativeQuoteQty will be < 0, meaning the data is not available at this time.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-accounts
-        -order-user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-accounts-order-user_data
 
         :param symbol: required
         :type symbol: str
@@ -2775,8 +2726,7 @@ class Client(object):
         When all symbols are returned, the number of requests counted against the rate limiter is equal to the number
         of symbols currently trading on the exchange.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-accounts
-        -open-order-user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-accounts-open-order-user_data
 
         :param symbol: optional
         :type symbol: str
@@ -2818,8 +2768,7 @@ class Client(object):
 
         For some historical orders cummulativeQuoteQty will be < 0, meaning the data is not available at this time.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-accounts
-        -open-order-user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-accounts-open-order-user_data
 
         :param symbol: required
         :type symbol: str
@@ -2874,8 +2823,7 @@ class Client(object):
 
         If fromId is set, it will get orders >= that fromId. Otherwise most recent orders are returned.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-accounts
-        -trade-list-user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-margin-accounts-trade-list-user_data
 
         :param symbol: required
         :type symbol: str
@@ -2929,8 +2877,7 @@ class Client(object):
     def get_max_margin_loan(self, **params):
         """Query max borrow amount for an asset
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-max-borrow
-        -user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-max-borrow-user_data
 
         :param asset: required
         :type asset: str
@@ -2951,8 +2898,7 @@ class Client(object):
     def get_max_margin_transfer(self, **params):
         """Query max transfer-out amount
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-max-transfer
-        -out-amount-user_data
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#query-max-transfer-out-amount-user_data
 
         :param asset: required
         :type asset: str
@@ -2977,8 +2923,7 @@ class Client(object):
 
         Can be used to keep the user stream alive.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#start-user-data
-        -stream-for-margin-account-user_stream
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#start-user-data-stream-for-margin-account-user_stream
 
         :returns: API response
 
@@ -2997,8 +2942,7 @@ class Client(object):
     def margin_stream_keepalive(self, listenKey):
         """PING a margin data stream to prevent a time out.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#ping-user-data-stream
-        -for-margin-account--user_stream
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#ping-user-data-stream-for-margin-account--user_stream
 
         :param listenKey: required
         :type listenKey: str
@@ -3014,14 +2958,13 @@ class Client(object):
         """
         params = {
             'listenKey': listenKey
-            }
+        }
         return self._request_margin_api('put', 'userDataStream', signed=True, data=params)
 
     def margin_stream_close(self, listenKey):
         """Close out a margin data stream.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#delete-user-data
-        -stream-for-margin-account--user_stream
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#delete-user-data-stream-for-margin-account--user_stream
 
         :param listenKey: required
         :type listenKey: str
@@ -3037,7 +2980,7 @@ class Client(object):
         """
         params = {
             'listenKey': listenKey
-            }
+        }
         return self._request_margin_api('delete', 'userDataStream', signed=True, data=params)
 
     # Sub Accounts
@@ -3045,8 +2988,7 @@ class Client(object):
     def get_sub_account_list(self, **params):
         """Query Sub-account List.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/wapi-api.md#query-sub-account
-        -listfor-master-account
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/wapi-api.md#query-sub-account-listfor-master-account
 
         :param email: optional
         :type email: str
@@ -3096,8 +3038,7 @@ class Client(object):
     def get_sub_account_transfer_history(self, **params):
         """Query Sub-account Transfer History.
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/master/wapi-api.md#query-sub-account
-        -transfer-historyfor-master-account
+        https://github.com/binance-exchange/binance-official-api-docs/blob/master/wapi-api.md#query-sub-account-transfer-historyfor-master-account
 
         :param email: required
         :type email: str
@@ -3144,8 +3085,7 @@ class Client(object):
     def create_sub_account_transfer(self, **params):
         """Execute sub-account transfer
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/9dbe0e961b80557bb19708a707c7fad08842b28e
-        /wapi-api.md#sub-account-transferfor-master-account
+        https://github.com/binance-exchange/binance-official-api-docs/blob/9dbe0e961b80557bb19708a707c7fad08842b28e/wapi-api.md#sub-account-transferfor-master-account
 
         :param fromEmail: required - Sender email
         :type fromEmail: str
@@ -3175,8 +3115,7 @@ class Client(object):
     def get_sub_account_assets(self, **params):
         """Fetch sub-account assets
 
-        https://github.com/binance-exchange/binance-official-api-docs/blob/9dbe0e961b80557bb19708a707c7fad08842b28e
-        /wapi-api.md#query-sub-account-assetsfor-master-account
+        https://github.com/binance-exchange/binance-official-api-docs/blob/9dbe0e961b80557bb19708a707c7fad08842b28e/wapi-api.md#query-sub-account-assetsfor-master-account
 
         :param email: required
         :type email: str

--- a/binance/client.py
+++ b/binance/client.py
@@ -171,6 +171,10 @@ class Client(object):
         if data:
             # sort post params
             kwargs['data'] = self._order_params(kwargs['data'])
+            # Remove any arguments with values of None.
+            null_args = [i for i,(key,value) in enumerate(kwargs['data']) if value is None]
+            for i in reversed(null_args):
+                del kwargs['data'][i]
 
         # if get request assign data array to params value for requests lib
         if data and (method == 'get' or force_params):


### PR DESCRIPTION
 - In Client._get_earliest_valid_timestamp(), endTime is set to None, which results in a server-side error.