### PR TITLE
Websockets: fix keepalive functionality for user socket

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -1066,6 +1066,9 @@ class Client(object):
         :type timeInForce: str
         :param quantity: required
         :type quantity: decimal
+        :param quoteOrderQty: amount the user wants to spend (when buying) or receive (when selling)
+            of the quote asset, applicable to MARKET orders
+        :type quoteOrderQty: decimal
         :param price: required
         :type price: str
         :param newClientOrderId: A unique id for the order. Automatically generated if not sent.
@@ -1279,6 +1282,9 @@ class Client(object):
         :type side: str
         :param quantity: required
         :type quantity: decimal
+        :param quoteOrderQty: amount the user wants to spend (when buying) or receive (when selling)
+            of the quote asset
+        :type quoteOrderQty: decimal
         :param newClientOrderId: A unique id for the order. Automatically generated if not sent.
         :type newClientOrderId: str
         :param newOrderRespType: Set the response JSON. ACK, RESULT, or FULL; default: RESULT.
@@ -1305,6 +1311,8 @@ class Client(object):
         :type symbol: str
         :param quantity: required
         :type quantity: decimal
+        :param quoteOrderQty: the amount the user wants to spend of the quote asset
+        :type quoteOrderQty: decimal
         :param newClientOrderId: A unique id for the order. Automatically generated if not sent.
         :type newClientOrderId: str
         :param newOrderRespType: Set the response JSON. ACK, RESULT, or FULL; default: RESULT.
@@ -1331,6 +1339,8 @@ class Client(object):
         :type symbol: str
         :param quantity: required
         :type quantity: decimal
+        :param quoteOrderQty: the amount the user wants to receive of the quote asset
+        :type quoteOrderQty: decimal
         :param newClientOrderId: A unique id for the order. Automatically generated if not sent.
         :type newClientOrderId: str
         :param newOrderRespType: Set the response JSON. ACK, RESULT, or FULL; default: RESULT.

--- a/binance/websockets.py
+++ b/binance/websockets.py
@@ -20,7 +20,8 @@ class RepeatTimer(threading.Timer):
     """Source: https://stackoverflow.com/a/48741004/304209."""
     def run(self):
         while not self.finished.wait(self.interval):
-            self.function(*self.args, **self.kwargs)
+            if not self.finished.is_set():
+                self.function(*self.args, **self.kwargs)
 
 
 class BinanceClientProtocol(WebSocketClientProtocol):

--- a/binance/websockets.py
+++ b/binance/websockets.py
@@ -541,10 +541,9 @@ class BinanceSocketManager(threading.Thread):
     def _keepalive_account_socket(self, socket_type):
         if socket_type == 'user':
             listen_key_func = self._client.stream_get_listen_key
-            callback = self._user_callback
         else:
             listen_key_func = self._client.margin_stream_get_listen_key
-            callback = self._margin_callback
+        callback = self._account_callbacks[socket_type]
         listen_key = listen_key_func()
         if listen_key != self._listen_keys[socket_type]:
             self._start_account_socket(socket_type, listen_key, callback)


### PR DESCRIPTION
The timer did not get restarted after it goes off. I replaced the regular timer with RepeatTimer, which makes sure the callback is called every time after USER_TIMEOUT seconds have passed.

Also fixes a bug in _keepalive_account_socket (raised AttributeError).