### PR TITLE
Arg for depth cache freq added

### DIFF
--- a/binance/websockets.py
+++ b/binance/websockets.py
@@ -170,7 +170,7 @@ class BinanceSocketManager(threading.Thread):
 
         socket_name = symbol.lower() + '@depth'
         if depth and depth != '1':
-            socket_name += depth
+            socket_name += str(depth)
         socket_name += '@' + str(freq) + 'ms'
         return self._start_socket(socket_name, callback)
 

--- a/binance/websockets.py
+++ b/binance/websockets.py
@@ -102,7 +102,7 @@ class BinanceSocketManager(threading.Thread):
         self._conns[path] = connectWS(factory, context_factory)
         return path
 
-    def start_depth_socket(self, symbol, callback, depth=None):
+    def start_depth_socket(self, symbol, callback, depth=None, freq=100):
         """Start a websocket for symbol market depth returning either a diff or a partial book
 
         https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md#partial-book-depth-streams
@@ -166,7 +166,9 @@ class BinanceSocketManager(threading.Thread):
             }
 
         """
-        socket_name = symbol.lower() + '@depth'
+        assert freq in [100, 1000], 'Depth freq can only be 100ms or 1000ms'
+
+        socket_name = symbol.lower() + '@depth@' + str(freq) + 'ms'
         if depth and depth != '1':
             socket_name = '{}{}'.format(socket_name, depth)
         return self._start_socket(socket_name, callback)

--- a/binance/websockets.py
+++ b/binance/websockets.py
@@ -168,9 +168,10 @@ class BinanceSocketManager(threading.Thread):
         """
         assert freq in [100, 1000], 'Depth freq can only be 100ms or 1000ms'
 
-        socket_name = symbol.lower() + '@depth@' + str(freq) + 'ms'
+        socket_name = symbol.lower() + '@depth'
         if depth and depth != '1':
-            socket_name = '{}{}'.format(socket_name, depth)
+            socket_name += depth
+        socket_name += '@' + str(freq) + 'ms'
         return self._start_socket(socket_name, callback)
 
     def start_kline_socket(self, symbol, callback, interval=Client.KLINE_INTERVAL_1MINUTE):

--- a/binance/websockets.py
+++ b/binance/websockets.py
@@ -102,7 +102,7 @@ class BinanceSocketManager(threading.Thread):
         self._conns[path] = connectWS(factory, context_factory)
         return path
 
-    def start_depth_socket(self, symbol, callback, depth=None, freq=100):
+    def start_depth_socket(self, symbol, callback, depth=None, freq=1000):
         """Start a websocket for symbol market depth returning either a diff or a partial book
 
         https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md#partial-book-depth-streams


### PR DESCRIPTION
Argument added to `start_depth_socket` to change the update frequency according to the [official doc](https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md#diff-depth-stream).

This resolved #487. There's also #435, but that was forked from the `feature/asyncio` branch and seems to be stale.