### PR TITLE
Update docs: new withdrawal address works already

### DIFF
--- a/docs/withdraw.rst
+++ b/docs/withdraw.rst
@@ -6,8 +6,6 @@ Withdraw Endpoints
 
 Make sure you enable Withdrawal permissions for your API Key to use this call.
 
-You must have withdrawn to the address through the website and approved the withdrawal via email before you can withdraw using the API.
-
 Raises a `BinanceWithdrawException <binance.html#binance.exceptions.BinanceWithdrawException>`_ if the withdraw fails.
 
 .. code:: python


### PR DESCRIPTION
This restriction is no longer applied by Binance; tested today (BTC and LTC withdrawals).