### PR TITLE
Added function to transfer funds from/to spot account and futures account

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -3567,10 +3567,18 @@ class Client(object):
         """
         return self._request_futures_api('get', 'ticker/leverageBracket', data=params)
 
+    def futures_account_transfer(self, **params):
+        """Execute transfer between spot account and futures account.
+
+        https://binance-docs.github.io/apidocs/futures/en/#new-future-account-transfer
+
+        """
+        return self._request_margin_api('post', 'futures/transfer', True, data=params)
+
     def transfer_history(self, **params):
         """Get future account transaction history list
 
-        https://binance-docs.github.io/apidocs/futures/en/#new-future-account-transfer
+        https://binance-docs.github.io/apidocs/futures/en/#get-future-account-transaction-history-list-user_data
 
         """
         return self._request_margin_api('get', 'futures/transfer', True, data=params)


### PR DESCRIPTION
I noticed that your library only implemented the "get" HTTP function on the transfer endpoint, which queries for transfer history.  I added the "post" version which allows you to transfer funds to/from your futures account from your spot account.

I noticed for margin trading, you explicitly made separate functions for each transfer direction: https://github.com/sammchardy/python-binance/blob/master/binance/client.py#L2500-L2558

But it seems the standard account stuff was more fleshed out in terms of documentation and function parameters.  The futures stuff seems to be left to the developer to read API docs, thus I did it that way.  I can implement separate to/from functions if you prefer.  Just let me know.