### PR TITLE
Added support for binance spot testnet

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -12,6 +12,7 @@ from .exceptions import BinanceAPIException, BinanceRequestException, BinanceWit
 class Client(object):
 
     API_URL = 'https://api.binance.{}/api'
+    TEST_API_URL = 'https://testnet.binance.vision/api'
     WITHDRAW_API_URL = 'https://api.binance.{}/wapi'
     MARGIN_API_URL = 'https://api.binance.{}/sapi'
     WEBSITE_URL = 'https://www.binance.{}'
@@ -77,7 +78,7 @@ class Client(object):
     AGG_BUYER_MAKES = 'm'
     AGG_BEST_MATCH = 'M'
 
-    def __init__(self, api_key=None, api_secret=None, requests_params=None, tld='com'):
+    def __init__(self, api_key=None, api_secret=None, requests_params=None, tld='com', test_account=False):
         """Binance API Client constructor
 
         :param api_key: Api Key
@@ -89,7 +90,10 @@ class Client(object):
 
         """
 
-        self.API_URL = self.API_URL.format(tld)
+        if test_account:
+            self.API_URL = self.TEST_API_URL
+        else:
+            self.API_URL = self.API_URL.format(tld)
         self.WITHDRAW_API_URL = self.WITHDRAW_API_URL.format(tld)
         self.MARGIN_API_URL = self.MARGIN_API_URL.format(tld)
         self.WEBSITE_URL = self.WEBSITE_URL.format(tld)

--- a/binance/websockets.py
+++ b/binance/websockets.py
@@ -71,7 +71,7 @@ class BinanceSocketManager(threading.Thread):
 
     DEFAULT_USER_TIMEOUT = 30 * 60  # 30 minutes
 
-    def __init__(self, client, user_timeout=DEFAULT_USER_TIMEOUT):
+    def __init__(self, client, user_timeout=DEFAULT_USER_TIMEOUT, test_account=False):
         """Initialise the BinanceSocketManager
 
         :param client: Binance API client
@@ -81,6 +81,9 @@ class BinanceSocketManager(threading.Thread):
 
         """
         threading.Thread.__init__(self)
+
+        if test_account:
+            self.STREAM_URL = 'wss://testnet.binance.vision/ws'
         self._conns = {}
         self._client = client
         self._user_timeout = user_timeout


### PR DESCRIPTION
I added spot testnet urls.
I know it's a bit flimsy because it's only for the rest and websockets api and not for withdrawal api for example, but still useful, as people would like to try to run some tests before moving to production mode.

This is according to the addresses here:
https://testnet.binance.vision/
