### PR TITLE
Add function to manually disconnect the aiohttp connection

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -2101,6 +2101,10 @@ class AsyncClient(BaseClient):
             headers=self._get_headers()
         )
         return session
+    
+    async def close_connection(self):
+        await self.session.close()
+        return
 
     async def _request(self, method, uri, signed, force_params=False, **kwargs):
 


### PR DESCRIPTION
To overcome the message "unclosed client connection", create a function with let the user manually disconnect the aiohttp session