### PR TITLE
Update Twisted dependency for security reasons

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ dateparser==0.7.0
 pyOpenSSL==19.0.0
 requests==2.22.0
 service-identity==17.0.0
-Twisted==19.7.0
+Twisted>=20.3.0


### PR DESCRIPTION
CVE-2020-10108
high severity
Vulnerable versions: < 20.3.0
Patched version: 20.3.0
In Twisted Web through 19.10.0, there was an HTTP request splitting vulnerability. When presented with two content-length headers, it ignored the first header. When the second content-length value was set to zero, the request body was interpreted as a pipelined request.

CVE-2020-10109
high severity
Vulnerable versions: < 20.3.0
Patched version: 20.3.0
In Twisted Web through 19.10.0, there was an HTTP request splitting vulnerability. When presented with a content-length and a chunked encoding header, the content-length took precedence and the remainder of the request body was interpreted as a pipelined request.