### PR TITLE
Clean up error response detection

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -226,7 +226,7 @@ class Client(object):
         Raises the appropriate exceptions when necessary; otherwise, returns the
         response.
         """
-        if not str(self.response.status_code).startswith('2'):
+        if not (200 <= self.response.status_code < 300):
             raise BinanceAPIException(self.response)
         try:
             return self.response.json()


### PR DESCRIPTION
This is more explicit than just checking the first digit and would still throw an exception if the status code was 20 or 2000 (obviously invalid), for example.