### PR TITLE
add futures_change_position_mode

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -3710,3 +3710,11 @@ class Client(object):
         
         """
         return self._request_futures_api('post', 'positionSide/dual', True, data=params)
+
+    def futures_get_position_mode(self, **params):
+        """Get position mode for authenticated account
+
+        https://binance-docs.github.io/apidocs/futures/en/#get-current-position-mode-user_data
+        
+        """
+        return self._request_futures_api('get', 'positionSide/dual', True, data=params)

--- a/binance/client.py
+++ b/binance/client.py
@@ -3702,3 +3702,11 @@ class Client(object):
 
         """
         return self._request_futures_api('get', 'income', True, data=params)
+
+    def futures_change_position_mode(self, **params):
+        """Change position mode for authenticated account
+
+        https://binance-docs.github.io/apidocs/futures/en/#change-position-mode-trade
+        
+        """
+        return self._request_futures_api('post', 'positionSide/dual', True, data=params)


### PR DESCRIPTION
I noticed that there are some endpoints in [binance future api doc](https://binance-docs.github.io/apidocs/futures/en/#change-log) not implemented in this python sdk yet. 

This PR add one endpoint [futures_change_position_mode](https://binance-docs.github.io/apidocs/futures/en/#change-position-mode-trade) to binance/client.py