### PR TITLE
Add 1 Month Interval (1M) for Historical Klines

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -5,7 +5,7 @@ import hmac
 import requests
 import time
 from operator import itemgetter
-from .helpers import date_to_milliseconds, interval_to_milliseconds
+from .helpers import date_to_milliseconds, interval_to_milliseconds, increment_month
 from .exceptions import BinanceAPIException, BinanceRequestException, BinanceWithdrawException
 
 
@@ -831,7 +831,10 @@ class Client(object):
                 break
 
             # increment next call by our timeframe
-            start_ts += timeframe
+            if interval == self.KLINE_INTERVAL_1MONTH:
+                start_ts = increment_month(start_ts)
+            else:
+                start_ts += timeframe
 
             # sleep after every 3rd call to be kind to the API
             if idx % 3 == 0:
@@ -912,7 +915,10 @@ class Client(object):
                 break
 
             # increment next call by our timeframe
-            start_ts += timeframe
+            if interval == self.KLINE_INTERVAL_1MONTH:
+                start_ts = increment_month(start_ts)
+            else:
+                start_ts += timeframe
 
             # sleep after every 3rd call to be kind to the API
             if idx % 3 == 0:

--- a/binance/helpers.py
+++ b/binance/helpers.py
@@ -4,6 +4,7 @@ import dateparser
 import pytz
 
 from datetime import datetime
+from dateutil.relativedelta import relativedelta
 
 
 def date_to_milliseconds(date_str):
@@ -50,3 +51,20 @@ def interval_to_milliseconds(interval):
         return int(interval[:-1]) * seconds_per_unit[interval[-1]] * 1000
     except (ValueError, KeyError):
         return None
+
+
+def increment_month(origin_ts):
+    """Increment a given timestamp by one month
+
+    :param origin_ts: original timestamp, e.g.: 1501545600000, 1504224000000, ...
+    :type origin_ts: int
+
+    :return:
+         Timestamp incremented by one month from a given timestamp
+    """
+    d = datetime.fromtimestamp(origin_ts/1000) + relativedelta(months=1)
+    # if the date is not timezone aware apply UTC timezone
+    if d.tzinfo is None or d.tzinfo.utcoffset(d) is None:
+        d = d.replace(tzinfo=pytz.utc)
+
+    return int(datetime.timestamp(d))

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -2,5 +2,5 @@ Helper Functions
 ================
 
 .. autoclass:: binance.helpers
-    :members: date_to_milliseconds, interval_to_milliseconds
+    :members: date_to_milliseconds, interval_to_milliseconds, increment_month
     :noindex:

--- a/tests/test_historical_klines.py
+++ b/tests/test_historical_klines.py
@@ -245,3 +245,120 @@ def test_historical_kline_generator_empty_response():
 
         with pytest.raises(StopIteration):
             next(klines)
+
+
+def test_historical_kline_with_month_interval():
+    """Test historical klines with one month interval"""
+
+    first_available_res = [
+        [
+            1498867200000,
+            "0.00005000",
+            "0.00005480",
+            "0.00001000",
+            "0.00003654",
+            "61059068.00000000",
+            1501545599999,
+            "2572.23205388",
+            33297,
+            "33906053.00000000",
+            "1442.17447471",
+            "100206524.84393587"
+        ]
+    ]
+    first_res = []
+    row = [
+        1519862400000,
+        "0.00101270",
+        "0.00167650",
+        "0.00083250",
+        "0.00159650",
+        "122814213.69000000",
+        1522540799999,
+        "142681.39725065",
+        3242765,
+        "68994444.35000000",
+        "79545.22096745",
+        "0"
+    ]
+
+    for i in range(0, 8):
+        first_res.append(row)
+
+    with requests_mock.mock() as m:
+        m.get(
+            "https://api.binance.com/api/v1/klines?interval=1M&limit=1&startTime=0&symbol=BNBBTC",
+            json=first_available_res,
+        )
+        m.get(
+            "https://api.binance.com/api/v1/klines?interval=1M&limit=500&startTime=1519862400000&endTime=1539234000000&symbol=BNBBTC",
+            json=first_res,
+        )
+        klines = client.get_historical_klines(
+            symbol="BNBBTC",
+            interval=Client.KLINE_INTERVAL_1MONTH,
+            start_str="1st March 2018",
+            end_str="11st Oct 2018 05:00:00",
+        )
+        assert len(klines) == 8
+
+
+def test_historical_kline_generator_with_month_interval():
+    """Test historical klines generator with one month interval"""
+
+    first_available_res = [
+        [
+            1498867200000,
+            "0.00005000",
+            "0.00005480",
+            "0.00001000",
+            "0.00003654",
+            "61059068.00000000",
+            1501545599999,
+            "2572.23205388",
+            33297,
+            "33906053.00000000",
+            "1442.17447471",
+            "100206524.84393587"
+        ]
+    ]
+    first_res = []
+    row = [
+        1519862400000,
+        "0.00101270",
+        "0.00167650",
+        "0.00083250",
+        "0.00159650",
+        "122814213.69000000",
+        1522540799999,
+        "142681.39725065",
+        3242765,
+        "68994444.35000000",
+        "79545.22096745",
+        "0"
+    ]
+
+    for i in range(0, 8):
+        first_res.append(row)
+
+    with requests_mock.mock() as m:
+        m.get(
+            "https://api.binance.com/api/v1/klines?interval=1M&limit=1&startTime=0&symbol=BNBBTC",
+            json=first_available_res,
+        )
+        m.get(
+            "https://api.binance.com/api/v1/klines?interval=1M&limit=500&startTime=1519862400000&endTime=1539234000000&symbol=BNBBTC",
+            json=first_res,
+        )
+        klines = client.get_historical_klines_generator(
+            symbol="BNBBTC",
+            interval=Client.KLINE_INTERVAL_1MONTH,
+            start_str=1519862400000,
+            end_str=1539234000000,
+        )
+
+        for i in range(8):
+            assert len(next(klines)) > 0
+
+        with pytest.raises(StopIteration):
+            next(klines)


### PR DESCRIPTION
The official binance API supports 1M interval for obtaining historical klines data. 
(ex. `https://api.binance.com/api/v1/klines?interval=1M&symbol=BNBBTC`)

So I added it.