### PR TITLE
Fixes for get_lending_product_list REST endpoint

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -3182,7 +3182,7 @@ class Client(object):
         https://binance-docs.github.io/apidocs/spot/en/#get-flexible-product-list-user_data
 
         """
-        return self._request_margin_api('get', 'lending/daily/product/list ', signed=True, data=params)
+        return self._request_margin_api('get', 'lending/daily/product/list', signed=True, data=params)
 
     def get_lending_daily_quota_left(self, **params):
         """Get Left Daily Purchase Quota of Flexible Product.


### PR DESCRIPTION
For now the endpoint is broken (having a whitespace in the end) and results in:
```
Traceback (most recent call last):
  File "/home/vilen/repos/crypto/venv/lib/python3.7/site-packages/IPython/core/interactiveshell.py", line 3343, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-18-e9f064622c02>", line 1, in <module>
    client.get_lending_product_list()
  File "/home/vilen/repos/crypto/venv/lib/python3.7/site-packages/binance/client.py", line 3185, in get_lending_product_list
    return self._request_margin_api('get', 'lending/daily/product/list ', signed=True, data=params)
  File "/home/vilen/repos/crypto/venv/lib/python3.7/site-packages/binance/client.py", line 212, in _request_margin_api
    return self._request(method, uri, signed, **kwargs)
  File "/home/vilen/repos/crypto/venv/lib/python3.7/site-packages/binance/client.py", line 197, in _request
    return self._handle_response()
  File "/home/vilen/repos/crypto/modules/utils.py", line 111, in _handle_response
    return super()._handle_response()
  File "/home/vilen/repos/crypto/venv/lib/python3.7/site-packages/binance/client.py", line 230, in _handle_response
    raise BinanceAPIException(self.response)
  File "/home/vilen/repos/crypto/venv/lib/python3.7/site-packages/binance/exceptions.py", line 13, in __init__
    self.code = json_res['code']
KeyError: 'code'
```