### PR TITLE
Added websockets functionality for isolated margin accounts

### DIFF
--- a/Endpoints.md
+++ b/Endpoints.md
@@ -475,12 +475,17 @@
     client.margin_stream_close(listenKey)
     ```
   - **POST /sapi/v1/userDataStream/isolated** (Create a ListenKey (Isolated).)
-  
-    > :warning: Not yet implemented
+    ```python 
+    client.isolated_margin_stream_get_listen_key(symbol)
+    ```
   - **PUT /sapi/v1/userDataStream/isolated** (Ping/Keep-alive a ListenKey (Isolated).)
-
-    > :warning: Not yet implemented
+    ```python 
+    client.isolated_margin_stream_keepalive(symbol, listenKey)
+    ```
   - **DELETE /sapi/v1/userDataStream/isolated** (Close a ListenKey (Isolated).)
+    ```python 
+    client.isolated_margin_stream_close(symbol, listenKey)
+    ```
 - *Savings Endpoints*
   - **GET /sapi/v1/lending/daily/product/list (HMAC SHA256)** (Get Flexible Product List (USER_DATA).)
     ```python 

--- a/binance/client.py
+++ b/binance/client.py
@@ -3424,12 +3424,14 @@ class Client(object):
         """
         return self._request_margin_api('get', 'margin/maxTransferable', signed=True, data=params)
 
+    # Cross-margin 
+
     def margin_stream_get_listen_key(self):
-        """Start a new margin data stream and return the listen key
+        """Start a new cross-margin data stream and return the listen key
         If a stream already exists it should return the same key.
         If the stream becomes invalid a new key is returned.
 
-        Can be used to keep the user stream alive.
+        Can be used to keep the stream alive.
 
         https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#start-user-data-stream-for-margin-account-user_stream
 
@@ -3444,11 +3446,11 @@ class Client(object):
         :raises: BinanceRequestException, BinanceAPIException
 
         """
-        res = self._request_margin_api('post', 'userDataStream', signed=True, data={})
+        res = self._request_margin_api('post', 'userDataStream', signed=False, data={})
         return res['listenKey']
 
     def margin_stream_keepalive(self, listenKey):
-        """PING a margin data stream to prevent a time out.
+        """PING a cross-margin data stream to prevent a time out.
 
         https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#ping-user-data-stream-for-margin-account--user_stream
 
@@ -3467,10 +3469,10 @@ class Client(object):
         params = {
             'listenKey': listenKey
         }
-        return self._request_margin_api('put', 'userDataStream', signed=True, data=params)
+        return self._request_margin_api('put', 'userDataStream', signed=False, data=params)
 
     def margin_stream_close(self, listenKey):
-        """Close out a margin data stream.
+        """Close out a cross-margin data stream.
 
         https://github.com/binance-exchange/binance-official-api-docs/blob/master/margin-api.md#delete-user-data-stream-for-margin-account--user_stream
 
@@ -3489,7 +3491,88 @@ class Client(object):
         params = {
             'listenKey': listenKey
         }
-        return self._request_margin_api('delete', 'userDataStream', signed=True, data=params)
+        return self._request_margin_api('delete', 'userDataStream', signed=False, data=params)
+
+    # Isolated margin 
+
+    def isolated_margin_stream_get_listen_key(self, symbol):
+        """Start a new isolated margin data stream and return the listen key
+        If a stream already exists it should return the same key.
+        If the stream becomes invalid a new key is returned.
+
+        Can be used to keep the stream alive.
+
+        https://binance-docs.github.io/apidocs/spot/en/#listen-key-isolated-margin
+
+        :param symbol: required - symbol for the isolated margin account
+        :type symbol: str
+
+        :returns: API response
+
+        .. code-block:: python
+
+            {
+                "listenKey":  "T3ee22BIYuWqmvne0HNq2A2WsFlEtLhvWCtItw6ffhhdmjifQ2tRbuKkTHhr"
+            }
+
+        :raises: BinanceRequestException, BinanceAPIException
+
+        """
+        params = {
+            'symbol': symbol
+        }
+        res = self._request_margin_api('post', 'userDataStream/isolated', signed=False, data=params)
+        return res['listenKey']
+
+    def isolated_margin_stream_keepalive(self, symbol, listenKey):
+        """PING an isolated margin data stream to prevent a time out.
+
+        https://binance-docs.github.io/apidocs/spot/en/#listen-key-isolated-margin
+
+        :param symbol: required - symbol for the isolated margin account
+        :type symbol: str
+        :param listenKey: required
+        :type listenKey: str
+
+        :returns: API response
+
+        .. code-block:: python
+
+            {}
+
+        :raises: BinanceRequestException, BinanceAPIException
+
+        """
+        params = {
+            'symbol': symbol,
+            'listenKey': listenKey
+        }
+        return self._request_margin_api('put', 'userDataStream/isolated', signed=False, data=params)
+
+    def isolated_margin_stream_close(self, symbol, listenKey):
+        """Close out an isolated margin data stream.
+
+        https://binance-docs.github.io/apidocs/spot/en/#listen-key-isolated-margin
+
+        :param symbol: required - symbol for the isolated margin account
+        :type symbol: str
+        :param listenKey: required
+        :type listenKey: str
+
+        :returns: API response
+
+        .. code-block:: python
+
+            {}
+
+        :raises: BinanceRequestException, BinanceAPIException
+
+        """
+        params = {
+            'symbol': symbol,
+            'listenKey': listenKey
+        }
+        return self._request_margin_api('delete', 'userDataStream/isolated', signed=False, data=params)
 
     # Lending Endpoints
 

--- a/docs/websockets.rst
+++ b/docs/websockets.rst
@@ -153,8 +153,8 @@ Valid interval values are `defined as enums <enums.html>`_.
     # set as 5000 to receive updates every 5 seconds
     conn_key = bm.start_miniticker_socket(process_message, 5000)
 
-`User Socket <binance.html#binance.websockets.BinanceSocketManager.start_user_socket>`_
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+User Socket
++++++++++++
 
 This watches for 3 different user events
 
@@ -164,9 +164,31 @@ This watches for 3 different user events
 
 The Manager handles keeping the socket alive.
 
+There are separate sockets for Spot, Cross-margin and separate Isolated margin accounts.
+
+`Spot trading <binance.html#binance.websockets.BinanceSocketManager.start_user_socket>`_
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 .. code:: python
 
     bm.start_user_socket(process_message)
+
+
+`Cross-margin <binance.html#binance.websockets.BinanceSocketManager.start_margin_socket>`_
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+    bm.start_margin_socket(process_message)
+
+
+`Isolated margin <binance.html#binance.websockets.BinanceSocketManager.start_isolated_margin_socket>`_
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+    bm.start_isolated_margin_socket(symbol, process_message)
+
 
 
 `Close a Socket <binance.html#binance.websockets.BinanceSocketManager.stop_socket>`_


### PR DESCRIPTION
Continuing the implementation of Isolated Margin accounts (closed PR #622 ), this now adds the websockets under BinanceSocketManager.  

I need this for my project so have written neatly and am posting a PR back to the community.

**Isolated Margin Socket**
* `bm.start_isolated_margin_socket(symbol, callback)` now opens a websocket on the Isolated Margin account for `symbol`.
* Uses the same API pattern as the spot and cross-margin endpoints, except that we also have to pass in the `symbol`.  
* Docs updated for the new WS endpoints.  I also added the cross-margin WS socket to the docs as it seemed to be missing.

Technical implementation note for maintainers ... 
* The `bm._listen_keys` `bm._timers` and `bm._account_callback` dictionaries need to expand with potentially many isolated margin symbol accounts.  For ease of access, we are using the isolated margin symbol as the key in these dictionaries.  The changes to the code nearer the bottom of websockets.py reflects this change.  I've moved some dictionary calls to use `get()` instead of addressing directly because it's possible that that someone calls a close on an isolated margin account that has not yet been opened and I wanted to avoid runtime exceptions.  Take a look and feel free to adjust.

And a small bug fix:
* the margin_stream endpoints in client.py were using `signed=True` but they are unsigned so I have set to `signed=False`. I have live tested the Spot, Cross-margin and Isolated Margin Websockets on my Binance account and they all provide live feeds.

Tests 
* Only manually live tested by hand as I'm not sure how to write tests easily against the live API ... now if Binance had a sandbox account that would make it easy for testing ...
