### PR TITLE
fix: uses ssl.optionsForClientTLS for testnet.binance wss

### DIFF
--- a/binance/websockets.py
+++ b/binance/websockets.py
@@ -98,7 +98,10 @@ class BinanceSocketManager(threading.Thread):
         factory.protocol = BinanceClientProtocol
         factory.callback = callback
         factory.reconnect = True
-        context_factory = ssl.ClientContextFactory()
+        if factory.host.startswith('testnet.binance'):
+            context_factory = ssl.optionsForClientTLS(factory.host)
+        else:
+            context_factory = ssl.ClientContextFactory()
 
         self._conns[path] = connectWS(factory, context_factory)
         return path


### PR DESCRIPTION
I was experiencing the #597 bug

By logging the python-binance websocket connection I found an SSL error when using testnet.binance.vision:

`
2021-02-03 21:33:03-0300 [-] SSL error: wrong version number (in ssl3_get_record)
`

I digged around and found this:

https://forum.crossbar.io/t/ssl-error-wrong-version-number-in-ssl3-get-record/1832

For logging the websocket error add this to the websockets.py header:
```python
import sys
from twisted.python import log
log.startLogging(sys.stdout)
```
It is working for me.