### PR TITLE
Mock URLs now match actual version

### DIFF
--- a/tests/test_api_request.py
+++ b/tests/test_api_request.py
@@ -15,7 +15,7 @@ def test_invalid_json():
 
     with pytest.raises(BinanceRequestException):
         with requests_mock.mock() as m:
-            m.get('https://www.binance.com/exchange/public/product', text='<head></html>')
+            m.get('https://www.binance.com/exchange-api/v1/public/asset-service/product/get-products', text='<head></html>')
             client.get_products()
 
 
@@ -25,7 +25,7 @@ def test_api_exception():
     with pytest.raises(BinanceAPIException):
         with requests_mock.mock() as m:
             json_obj = {"code": 1002, "msg": "Invalid API call"}
-            m.get('https://api.binance.com/api/v1/time', json=json_obj, status_code=400)
+            m.get('https://api.binance.com/api/v3/time', json=json_obj, status_code=400)
             client.get_server_time()
 
 
@@ -35,7 +35,7 @@ def test_api_exception_invalid_json():
     with pytest.raises(BinanceAPIException):
         with requests_mock.mock() as m:
             not_json_str = "<html><body>Error</body></html>"
-            m.get('https://api.binance.com/api/v1/time', text=not_json_str, status_code=400)
+            m.get('https://api.binance.com/api/v3/time', text=not_json_str, status_code=400)
             client.get_server_time()
 
 

--- a/tests/test_historical_klines.py
+++ b/tests/test_historical_klines.py
@@ -23,9 +23,9 @@ def test_exact_amount():
     second_res = []
 
     with requests_mock.mock() as m:
-        m.get('https://api.binance.com/api/v1/klines?interval=1m&limit=1&startTime=0&symbol=BNBBTC', json=first_available_res)
-        m.get('https://api.binance.com/api/v1/klines?interval=1m&limit=500&startTime=1519862400000&symbol=BNBBTC', json=first_res)
-        m.get('https://api.binance.com/api/v1/klines?interval=1m&limit=500&startTime=1519892400000&symbol=BNBBTC', json=second_res)
+        m.get('https://api.binance.com/api/v3/klines?interval=1m&limit=1&startTime=0&symbol=BNBBTC', json=first_available_res)
+        m.get('https://api.binance.com/api/v3/klines?interval=1m&limit=500&startTime=1519862400000&symbol=BNBBTC', json=first_res)
+        m.get('https://api.binance.com/api/v3/klines?interval=1m&limit=500&startTime=1519892400000&symbol=BNBBTC', json=second_res)
         klines = client.get_historical_klines(
             symbol="BNBBTC",
             interval=Client.KLINE_INTERVAL_1MINUTE,
@@ -74,11 +74,11 @@ def test_start_and_end_str():
 
     with requests_mock.mock() as m:
         m.get(
-            "https://api.binance.com/api/v1/klines?interval=1m&limit=1&startTime=0&symbol=BNBBTC",
+            "https://api.binance.com/api/v3/klines?interval=1m&limit=1&startTime=0&symbol=BNBBTC",
             json=first_available_res,
         )
         m.get(
-            "https://api.binance.com/api/v1/klines?interval=1m&limit=500&startTime=1519862400000&endTime=1519880400000&symbol=BNBBTC",
+            "https://api.binance.com/api/v3/klines?interval=1m&limit=500&startTime=1519862400000&endTime=1519880400000&symbol=BNBBTC",
             json=first_res,
         )
         klines = client.get_historical_klines(
@@ -130,11 +130,11 @@ def test_start_and_end_timestamp():
 
     with requests_mock.mock() as m:
         m.get(
-            "https://api.binance.com/api/v1/klines?interval=1m&limit=1&startTime=0&symbol=BNBBTC",
+            "https://api.binance.com/api/v3/klines?interval=1m&limit=1&startTime=0&symbol=BNBBTC",
             json=first_available_res,
         )
         m.get(
-            "https://api.binance.com/api/v1/klines?interval=1m&limit=500&startTime=1519862400000&endTime=1519880400000&symbol=BNBBTC",
+            "https://api.binance.com/api/v3/klines?interval=1m&limit=500&startTime=1519862400000&endTime=1519880400000&symbol=BNBBTC",
             json=first_res,
         )
         klines = client.get_historical_klines(
@@ -186,11 +186,11 @@ def test_historical_kline_generator():
 
     with requests_mock.mock() as m:
         m.get(
-            "https://api.binance.com/api/v1/klines?interval=1m&limit=1&startTime=0&symbol=BNBBTC",
+            "https://api.binance.com/api/v3/klines?interval=1m&limit=1&startTime=0&symbol=BNBBTC",
             json=first_available_res,
         )
         m.get(
-            "https://api.binance.com/api/v1/klines?interval=1m&limit=500&startTime=1519862400000&endTime=1519880400000&symbol=BNBBTC",
+            "https://api.binance.com/api/v3/klines?interval=1m&limit=500&startTime=1519862400000&endTime=1519880400000&symbol=BNBBTC",
             json=first_res,
         )
         klines = client.get_historical_klines_generator(
@@ -229,11 +229,11 @@ def test_historical_kline_generator_empty_response():
 
     with requests_mock.mock() as m:
         m.get(
-            "https://api.binance.com/api/v1/klines?interval=1m&limit=1&startTime=0&symbol=BNBBTC",
+            "https://api.binance.com/api/v3/klines?interval=1m&limit=1&startTime=0&symbol=BNBBTC",
             json=first_available_res,
         )
         m.get(
-            "https://api.binance.com/api/v1/klines?interval=1m&limit=500&startTime=1519862400000&endTime=1519880400000&symbol=BNBBTC",
+            "https://api.binance.com/api/v3/klines?interval=1m&limit=500&startTime=1519862400000&endTime=1519880400000&symbol=BNBBTC",
             json=first_res,
         )
         klines = client.get_historical_klines_generator(


### PR DESCRIPTION
I noticed that some tests were failing because the actual URLs didn't match the mock URLs.
I updated the mock URLs so that the tests now pass.