### PR TITLE
Update client.py

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -1911,7 +1911,7 @@ class Client(object):
 
         """
         res = self._request_withdraw_api('get', 'accountStatus.html', True, data=params)
-        if not res['success']:
+        if not res.get('success'):
             raise BinanceWithdrawException(res['msg'])
         return res
 


### PR DESCRIPTION
In the event `res` returns an error, there would be no key with the value `success` in the returned dict.  This results in a KeyError which doesn't provide the caller any information about the reason for the error.  Instead calling `get` will simply default to `None` if no `success` key is present - and raise the appropriate error with the response `msg`.