### PR TITLE
Add Get Daily Account Snapshot endpoint

### DIFF
--- a/Endpoints.md
+++ b/Endpoints.md
@@ -14,9 +14,11 @@
     ```
   - **GET /sapi/v1/capital/config/getall (HMAC SHA256)** (Get information of coins (available for deposit and withdraw) for user.)
    
-    > :warning: Not yet implemented
   - **GET /sapi/v1/accountSnapshot (HMAC SHA256)** (Daily Account Snapshot (USER_DATA).)
-  
+    ```python 
+    client.get_account_snapshot(type='SPOT')
+    ```
+
     > :warning: Not yet implemented 
   - **POST /sapi/v1/account/disableFastWithdrawSwitch (HMAC SHA256)** (Disable Fast Withdraw Switch (USER_DATA).)
   

--- a/binance/client.py
+++ b/binance/client.py
@@ -5583,3 +5583,111 @@ class Client(object):
 
         """
         return self._request_margin_api('get', 'capital/config/getall', True, data=params)
+
+    def get_account_snapshot(self, **params):
+        """Get daily account snapshot of specific type.
+
+        https://binance-docs.github.io/apidocs/spot/en/#daily-account-snapshot-user_data
+
+        :param type: required. Valid values are SPOT/MARGIN/FUTURES.
+        :type type: string
+        :param startTime: optional
+        :type startTime: int
+        :param endTime: optional
+        :type endTime: int
+        :param limit: optional
+        :type limit: int
+        :param recvWindow: optional
+        :type recvWindow: int
+        :param timestamp: requred
+        :type timestamp: int
+
+        :returns: API response
+
+        .. code-block:: python
+            {
+               "code":200, // 200 for success; others are error codes
+               "msg":"", // error message
+               "snapshotVos":[
+                  {
+                     "data":{
+                        "balances":[
+                           {
+                              "asset":"BTC",
+                              "free":"0.09905021",
+                              "locked":"0.00000000"
+                           },
+                           {
+                              "asset":"USDT",
+                              "free":"1.89109409",
+                              "locked":"0.00000000"
+                           }
+                        ],
+                        "totalAssetOfBtc":"0.09942700"
+                     },
+                     "type":"spot",
+                     "updateTime":1576281599000
+                  }
+               ]
+            }
+        OR
+            {
+               "code":200, // 200 for success; others are error codes
+               "msg":"", // error message
+               "snapshotVos":[
+                  {
+                     "data":{
+                        "marginLevel":"2748.02909813",
+                        "totalAssetOfBtc":"0.00274803",
+                        "totalLiabilityOfBtc":"0.00000100",
+                        "totalNetAssetOfBtc":"0.00274750",
+                        "userAssets":[
+                           {
+                              "asset":"XRP",
+                              "borrowed":"0.00000000",
+                              "free":"1.00000000",
+                              "interest":"0.00000000",
+                              "locked":"0.00000000",
+                              "netAsset":"1.00000000"
+                           }
+                        ]
+                     },
+                     "type":"margin",
+                     "updateTime":1576281599000
+                  }
+               ]
+            }
+        OR
+            {
+               "code":200, // 200 for success; others are error codes
+               "msg":"", // error message
+               "snapshotVos":[
+                  {
+                     "data":{
+                        "assets":[
+                           {
+                              "asset":"USDT",
+                              "marginBalance":"118.99782335",
+                              "walletBalance":"120.23811389"
+                           }
+                        ],
+                        "position":[
+                           {
+                              "entryPrice":"7130.41000000",
+                              "markPrice":"7257.66239673",
+                              "positionAmt":"0.01000000",
+                              "symbol":"BTCUSDT",
+                              "unRealizedProfit":"1.24029054"
+                           }
+                        ]
+                     },
+                     "type":"futures",
+                     "updateTime":1576281599000
+                  }
+               ]
+            }
+
+        :raises: BinanceRequestException, BinanceAPIException
+
+        """
+        return self._request_margin_api('get', 'accountSnapshot', True, data=params)

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -56,6 +56,14 @@ Get information of coins (available for deposit and withdraw) for user
 
     info = client.get_all_coins_info()
 
+`Get Get Daily Account Snapshot <binance.html#binance.client.Client.get_account_snapshot>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Get daily account snapshot of specific type. Valid types: SPOT/MARGIN/FUTURES.
+
+.. code:: python
+    info = client.get_account_snapshot(type='SPOT')
+
 `Get Current Products <binance.html#binance.client.Client.get_products>`_
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
In this PR I've added the support for the Daily Account Snapshot endpoint, and also updated the docs.

Daily Account Snapshot (USER_DATA)
GET /sapi/v1/accountSnapshot (HMAC SHA256) 

See Binance docs for more informations about this endpoint :
https://binance-docs.github.io/apidocs/spot/en/#daily-account-snapshot-user_data