### PR TITLE
Add Disable/Enable Fast Withdraw Switch endpoints.

### DIFF
--- a/Endpoints.md
+++ b/Endpoints.md
@@ -21,11 +21,13 @@
     client.get_account_snapshot(type='SPOT')
     ```
   - **POST /sapi/v1/account/disableFastWithdrawSwitch (HMAC SHA256)** (Disable Fast Withdraw Switch (USER_DATA).)
-  
-    > :warning: Not yet implemented  
+    ```python 
+    client.disable_fast_withdraw_switch(type='SPOT')
+    ``` 
   - **POST /sapi/v1/account/enableFastWithdrawSwitch (HMAC SHA256)** (Enable Fast Withdraw Switch (USER_DATA).)
-  
-    > :warning: Not yet implemented  
+    ```python 
+    client.enable_fast_withdraw_switch(type='SPOT')
+    ```
   - **POST /sapi/v1/capital/withdraw/apply (HMAC SHA256)** (Withdraw [SAPI]: Submit a withdraw request.)
   
     > :warning: Not yet implemented  

--- a/binance/client.py
+++ b/binance/client.py
@@ -5691,3 +5691,33 @@ class Client(object):
 
         """
         return self._request_margin_api('get', 'accountSnapshot', True, data=params)
+
+    def disable_fast_withdraw_switch(self, **params):
+        """Disable Fast Withdraw Switch
+
+        https://binance-docs.github.io/apidocs/spot/en/#disable-fast-withdraw-switch-user_data
+
+        :param recvWindow: optional
+        :type recvWindow: int
+
+        :returns: API response
+
+        :raises: BinanceRequestException, BinanceAPIException
+
+        """
+        return self._request_margin_api('post', 'disableFastWithdrawSwitch', True, data=params)
+
+    def enable_fast_withdraw_switch(self, **params):
+        """Enable Fast Withdraw Switch
+
+        https://binance-docs.github.io/apidocs/spot/en/#enable-fast-withdraw-switch-user_data
+
+        :param recvWindow: optional
+        :type recvWindow: int
+
+        :returns: API response
+
+        :raises: BinanceRequestException, BinanceAPIException
+
+        """
+        return self._request_margin_api('post', 'enableFastWithdrawSwitch', True, data=params)

--- a/docs/account.rst
+++ b/docs/account.rst
@@ -215,3 +215,19 @@ Account
 .. code:: python
 
     history = client.get_asset_dividend_history()
+
+
+`Disable Fast Withdraw Switch <binance.html#binance.client.Client.disable_fast_withdraw_switch>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code:: python
+
+    client.disable_fast_withdraw_switch()
+
+
+`Enable Fast Withdraw Switch <binance.html#binance.client.Client.enable_fast_withdraw_switch>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code:: python
+
+    client.enable_fast_withdraw_switch()


### PR DESCRIPTION
In this PR I've added the support for the `Disable Fast Withdraw Switch` and `Enable Fast Withdraw Switch` endpoints, and also updated the docs.

Disable Fast Withdraw Switch (USER_DATA)
POST /sapi/v1/account/disableFastWithdrawSwitch (HMAC SHA256)
https://binance-docs.github.io/apidocs/spot/en/#disable-fast-withdraw-switch-user_data

Enable Fast Withdraw Switch (USER_DATA)
POST /sapi/v1/account/enableFastWithdrawSwitch (HMAC SHA256) 
https://binance-docs.github.io/apidocs/spot/en/#enable-fast-withdraw-switch-user_data