### PR TITLE
fix: Keepalive a user data stream to prevent a time out

### DIFF
--- a/binance/websockets.py
+++ b/binance/websockets.py
@@ -740,6 +740,12 @@ class BinanceSocketManager(threading.Thread):
         if listen_key != self._listen_keys[socket_type]:
             self._start_account_socket(socket_type, listen_key, callback)
         else:
+            if socket_type == 'user':
+                self._client.stream_keepalive(listen_key)
+            elif socket_type == 'margin':  # cross-margin
+                self._client.margin_stream_keepalive(listen_key)
+            else:  # isolated margin
+                self._client.isolated_margin_stream_keepalive(listen_key)
             self._start_socket_timer(socket_type)
 
     def stop_socket(self, conn_key):

--- a/binance/websockets.py
+++ b/binance/websockets.py
@@ -726,17 +726,15 @@ class BinanceSocketManager(threading.Thread):
 
     def _keepalive_account_socket(self, socket_type):
         if socket_type == 'user':
-            listen_key_func = self._client.stream_get_listen_key
             callback = self._account_callbacks[socket_type]
-            listen_key = listen_key_func()
+            listen_key = self._client.stream_get_listen_key()
         elif socket_type == 'margin':  # cross-margin
-            listen_key_func = self._client.margin_stream_get_listen_key
             callback = self._account_callbacks[socket_type]
-            listen_key = listen_key_func()
+            listen_key = self._client.margin_stream_get_listen_key()
         else:  # isolated margin
-            listen_key_func = self._client.isolated_margin_stream_get_listen_key
             callback = self._account_callbacks.get(socket_type, None)
-            listen_key = listen_key_func(socket_type)  # Passing symbol for islation margin
+            listen_key = self._client.isolated_margin_stream_get_listen_key(socket_type)  # Passing symbol for isolated margin
+        
         if listen_key != self._listen_keys[socket_type]:
             self._start_account_socket(socket_type, listen_key, callback)
         else:
@@ -745,7 +743,7 @@ class BinanceSocketManager(threading.Thread):
             elif socket_type == 'margin':  # cross-margin
                 self._client.margin_stream_keepalive(listen_key)
             else:  # isolated margin
-                self._client.isolated_margin_stream_keepalive(socket_type, listen_key)  # Passing symbol for islation margin
+                self._client.isolated_margin_stream_keepalive(socket_type, listen_key)  # Passing symbol for isolated margin
             self._start_socket_timer(socket_type)
 
     def stop_socket(self, conn_key):

--- a/binance/websockets.py
+++ b/binance/websockets.py
@@ -745,7 +745,7 @@ class BinanceSocketManager(threading.Thread):
             elif socket_type == 'margin':  # cross-margin
                 self._client.margin_stream_keepalive(listen_key)
             else:  # isolated margin
-                self._client.isolated_margin_stream_keepalive(listen_key)
+                self._client.isolated_margin_stream_keepalive(socket_type, listen_key)  # Passing symbol for islation margin
             self._start_socket_timer(socket_type)
 
     def stop_socket(self, conn_key):


### PR DESCRIPTION
If the stream is open, ping it every `DEFAULT_USER_TIMEOUT`:
Keepalive a user data stream to prevent a time out. User data streams will close after 60 minutes. It's recommended to send a ping about every 30 minutes (Which is the `DEFAULT_USER_TIMEOUT`).

Fixes #712 
Fixes #440 