### PR TITLE
Added Vanilla Options Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist/
 python_binance.egg-info/
 *__pycache__
 *.egg-info/
+.idea/
+venv/

--- a/Endpoints.md
+++ b/Endpoints.md
@@ -829,6 +829,56 @@
     ```python
     client.options_historical_trades(symbol, fromId, limit)
     ```
+- *Account and trading interface*
+  - **GET /vapi/v1/account (HMAC SHA256)** (Account asset info (USER_DATA))
+    ```python
+    client.options_account_info(recvWindow)
+    ```
+  - **POST /vapi/v1/transfer (HMAC SHA256)** (Funds transfer (USER_DATA))
+    ```python
+    client.options_funds_transfer(currency, type, amount, recvWindow)
+    ```
+  - **GET /vapi/v1/position (HMAC SHA256)** (Option holdings info (USER_DATA))
+    ```python
+    client.options_positions(symbol, recvWindow)
+    ```
+  - **POST /vapi/v1/bill (HMAC SHA256)** (Account funding flow (USER_DATA))
+    ```python
+    client.options_bill(currency, recordId, startTime, endTime, limit, recvWindow)
+    ```
+  - **POST /vapi/v1/order (HMAC SHA256)** (Option order (TRADE))
+    ```python
+    client.options_place_order(symbol, side, type, quantity, price, timeInForce, reduceOnly, postOnly, \
+        newOrderRespType, clientOrderId, recvWindow, recvWindow)
+    ```
+  - **POST /vapi/v1/batchOrders (HMAC SHA256)** (Place Multiple Option orders (TRADE))
+    ```python
+    client.options_place_batch_order(orders, recvWindow)
+    ```
+  - **DELETE /vapi/v1/order (HMAC SHA256)** (Cancel Option order (TRADE))
+    ```python
+    client.options_cancel_order(symbol, orderId, clientOrderId, recvWindow)
+    ```
+  - **DELETE /vapi/v1/batchOrders (HMAC SHA256)** (Cancel Multiple Option orders (TRADE))
+    ```python
+    client.options_cancel_batch_order(symbol, orderIds, clientOrderIds, recvWindow)
+    ```
+  - **DELETE /vapi/v1/allOpenOrders (HMAC SHA256)** (Cancel all Option orders (TRADE))
+    ```python
+    client.options_cancel_all_orders(symbol, recvWindow)
+    ```
+  - **GET /vapi/v1/order (HMAC SHA256)** (Query Option order (TRADE))
+    ```python
+    client.options_query_order(symbol, orderId, clientOrderId, recvWindow)
+    ```
+  - **GET /vapi/v1/openOrders (HMAC SHA256)** (Query current pending Option orders (TRADE))
+    ```python
+    client.options_query_pending_orders(symbol, orderId, startTime, endTime, limit, recvWindow)
+    ```
+  - **GET /vapi/v1/historyOrders (HMAC SHA256)** (Query Option order history (TRADE))
+    ```python
+    client.options_query_order_history(symbol, orderId, startTime, endTime, limit, recvWindow)
+    ```
 ### [COIN-M Futures](https://binance-docs.github.io/apidocs/delivery/en/)
 > :warning: Not yet implemented
 ### [USDT-M Futures testnet](https://binance-docs.github.io/apidocs/testnet/en/)

--- a/Endpoints.md
+++ b/Endpoints.md
@@ -879,6 +879,10 @@
     ```python
     client.options_query_order_history(symbol, orderId, startTime, endTime, limit, recvWindow)
     ```
+  - **GET /vapi/v1/userTrades (HMAC SHA256)** (Option Trade List (USER_DATA))
+    ```python
+    client.options_user_trades(symbol, fromId, startTime, endTime, limit, recvWindow)
+    ```
 ### [COIN-M Futures](https://binance-docs.github.io/apidocs/delivery/en/)
 > :warning: Not yet implemented
 ### [USDT-M Futures testnet](https://binance-docs.github.io/apidocs/testnet/en/)

--- a/Endpoints.md
+++ b/Endpoints.md
@@ -783,6 +783,52 @@
     > :warning: Not yet implemented
 - *User Data Streams*
     > :warning: Not yet implemented
+### [Vanilla Options](https://binance-docs.github.io/apidocs/voptions/en/)
+- *Quoting interface*
+  - **GET /vapi/v1/ping** (Test connectivity)
+    ```python
+    client.options_ping()
+    ```
+  - **GET /vapi/v1/time** (Get server time)
+    ```python
+    client.options_time()
+    ```
+  - **GET /vapi/v1/optionInfo** (Get current trading pair info)
+    ```python
+    client.options_info()
+    ```
+  - **GET /vapi/v1/exchangeInfo** (Get current limit info and trading pair info)
+    ```python
+    client.options_exchange_info()
+    ```
+  - **GET /vapi/v1/index** (Get the spot index price)
+    ```python
+    client.options_index_price(underlying)
+    ```
+  - **GET /vapi/v1/ticker** (Get the latest price)
+    ```python
+    client.options_price(symbol)
+    ```
+  - **GET /vapi/v1/mark** (Get the latest mark price)
+    ```python
+    client.options_mark_price(symbol)
+    ```
+  - **GET /vapi/v1/depth** (Depth information)
+    ```python
+    client.options_order_book(symbol, limit)
+    ```
+  - **GET /vapi/v1/klines** (Candle data)
+    ```python
+    client.options_klines(symbol, interval, startTime, endTime, limit)
+    ```
+  - **GET /vapi/v1/trades** (Recently completed Option trades)
+    ```python
+    client.options_recent_trades(symbol, limit)
+    ```
+  - **GET /vapi/v1/historicalTrades** (Query trade history)
+    ```python
+    client.options_historical_trades(symbol, fromId, limit)
+    ```
 ### [COIN-M Futures](https://binance-docs.github.io/apidocs/delivery/en/)
 > :warning: Not yet implemented
 ### [USDT-M Futures testnet](https://binance-docs.github.io/apidocs/testnet/en/)

--- a/binance/client.py
+++ b/binance/client.py
@@ -19,12 +19,14 @@ class Client(object):
     FUTURES_DATA_URL = 'https://fapi.binance.{}/futures/data'
     FUTURES_COIN_URL = "https://dapi.binance.{}/dapi"
     FUTURES_COIN_DATA_URL = "https://dapi.binance.{}/futures/data"
+    OPTIONS_URL = 'https://vapi.binance.{}/vapi'
     PUBLIC_API_VERSION = 'v1'
     PRIVATE_API_VERSION = 'v3'
     WITHDRAW_API_VERSION = 'v3'
     MARGIN_API_VERSION = 'v1'
     FUTURES_API_VERSION = 'v1'
     FUTURES_API_VERSION2 = "v2"
+    OPTIONS_API_VERSION = 'v1'
 
     SYMBOL_TYPE_SPOT = 'SPOT'
 
@@ -120,6 +122,7 @@ class Client(object):
         self.FUTURES_DATA_URL = self.FUTURES_DATA_URL.format(tld)
         self.FUTURES_COIN_URL = self.FUTURES_COIN_URL.format(tld)
         self.FUTURES_COIN_DATA_URL = self.FUTURES_COIN_DATA_URL.format(tld)
+        self.OPTIONS_URL = self.OPTIONS_URL.format(tld)
 
         self.API_KEY = api_key
         self.API_SECRET = api_secret

--- a/binance/client.py
+++ b/binance/client.py
@@ -6210,3 +6210,24 @@ class Client(object):
 
         """
         return self._request_options_api('get', 'historyOrders', signed=True, data=params)
+
+    def options_user_trades(self, **params):
+        """Option Trade List (USER_DATA)
+
+        https://binance-docs.github.io/apidocs/voptions/en/#option-trade-list-user_data
+
+        :param symbol: required - Option trading pair - BTC-200730-9000-C
+        :type symbol: str
+        :param fromId: optional - Trade id to fetch from. Default gets most recent trades. - 4611875134427365376
+        :type orderId: int
+        :param startTime: optional - Start Time - 1593511200000
+        :type startTime: int
+        :param endTime: optional - End Time - 1593511200000
+        :type endTime: int
+        :param limit: optional - Number of result sets returned Default:100 Max:1000 - 100
+        :type limit: int
+        :param recvWindow: optional
+        :type recvWindow: int
+
+        """
+        return self._request_options_api('get', 'userTrades', signed=True, data=params)

--- a/binance/client.py
+++ b/binance/client.py
@@ -20,6 +20,7 @@ class Client(object):
     FUTURES_COIN_URL = "https://dapi.binance.{}/dapi"
     FUTURES_COIN_DATA_URL = "https://dapi.binance.{}/futures/data"
     OPTIONS_URL = 'https://vapi.binance.{}/vapi'
+    OPTIONS_TESTNET_URL = 'https://testnet.binanceops.{}/vapi'
     PUBLIC_API_VERSION = 'v1'
     PRIVATE_API_VERSION = 'v3'
     WITHDRAW_API_VERSION = 'v3'
@@ -102,7 +103,7 @@ class Client(object):
     MINING_TO_USDT_FUTURE = "MINING_UMFUTURE"
     MINING_TO_FIAT = "MINING_C2C"
 
-    def __init__(self, api_key=None, api_secret=None, requests_params=None, tld='com'):
+    def __init__(self, api_key=None, api_secret=None, requests_params=None, tld='com', testnet=False):
         """Binance API Client constructor
 
         :param api_key: Api Key
@@ -111,6 +112,8 @@ class Client(object):
         :type api_secret: str.
         :param requests_params: optional - Dictionary of requests params to use for all calls
         :type requests_params: dict.
+        :param testnet: Use testnet environment - only available for vanilla options at the moment
+        :type testnet: bool
 
         """
 
@@ -123,12 +126,14 @@ class Client(object):
         self.FUTURES_COIN_URL = self.FUTURES_COIN_URL.format(tld)
         self.FUTURES_COIN_DATA_URL = self.FUTURES_COIN_DATA_URL.format(tld)
         self.OPTIONS_URL = self.OPTIONS_URL.format(tld)
+        self.OPTIONS_TESTNET_URL = self.OPTIONS_TESTNET_URL.format(tld)
 
         self.API_KEY = api_key
         self.API_SECRET = api_secret
         self.session = self._init_session()
         self._requests_params = requests_params
         self.response = None
+        self.testnet = testnet
         self.timestamp_offset = 0
 
         # init DNS and SSL cert
@@ -172,7 +177,11 @@ class Client(object):
         return self.FUTURES_COIN_DATA_URL + "/" + path
 
     def _create_options_api_uri(self, path):
-        return self.OPTIONS_URL + '/' + self.OPTIONS_API_VERSION + '/' + path
+        if self.testnet:
+            url =  self.OPTIONS_TESTNET_URL
+        else:
+            url = self.OPTIONS_URL
+        return url + '/' + self.OPTIONS_API_VERSION + '/' + path
 
     def _generate_signature(self, data):
 

--- a/binance/client.py
+++ b/binance/client.py
@@ -5987,3 +5987,217 @@ class Client(object):
 
         """
         return self._request_options_api('get', 'historicalTrades', data=params)
+
+    # Account and trading interface endpoints
+
+    def options_account_info(self, **params):
+        """Account asset info (USER_DATA)
+
+        https://binance-docs.github.io/apidocs/voptions/en/#account-asset-info-user_data
+
+        :param recvWindow: optional
+        :type recvWindow: int
+
+        """
+        return self._request_options_api('get', 'account', data=params)
+
+    def options_funds_transfer(self, **params):
+        """Funds transfer (USER_DATA)
+
+        https://binance-docs.github.io/apidocs/voptions/en/#funds-transfer-user_data
+
+        :param currency: required - Asset type - USDT
+        :type currency: str
+        :param type: required - IN: Transfer from spot account to option account OUT: Transfer from option account to spot account - IN
+        :type type: str (ENUM)
+        :param amount: required - Amount - 10000
+        :type amount: float
+        :param recvWindow: optional
+        :type recvWindow: int
+
+        """
+        return self._request_options_api('post', 'transfer', data=params)
+
+    def options_positions(self, **params):
+        """Option holdings info (USER_DATA)
+
+        https://binance-docs.github.io/apidocs/voptions/en/#option-holdings-info-user_data
+
+        :param symbol: optional - Option trading pair - BTC-200730-9000-C
+        :type symbol: str
+        :param recvWindow: optional
+        :type recvWindow: int
+
+        """
+        return self._request_options_api('get', 'position', data=params)
+
+    def options_bill(self, **params):
+        """Account funding flow (USER_DATA)
+
+        https://binance-docs.github.io/apidocs/voptions/en/#account-funding-flow-user_data
+
+        :param currency: required - Asset type - USDT
+        :type currency: str
+        :param recordId: optional - Return the recordId and subsequent data, the latest data is returned by default - 100000
+        :type recordId: int
+        :param startTime: optional - Start Time - 1593511200000
+        :type startTime: int
+        :param endTime: optional - End Time - 1593511200000
+        :type endTime: int
+        :param limit: optional - Number of result sets returned Default:100 Max:1000 - 100
+        :type limit: int
+        :param recvWindow: optional
+        :type recvWindow: int
+
+        """
+        return self._request_options_api('post', 'bill', data=params)
+
+    def options_place_order(self, **params):
+        """Option order (TRADE)
+
+        https://binance-docs.github.io/apidocs/voptions/en/#option-order-trade
+
+        :param symbol: required - Option trading pair - BTC-200730-9000-C
+        :type symbol: str
+        :param side: required - Buy/sell direction: SELL, BUY - BUY
+        :type side: str (ENUM)
+        :param type: required - Order Type: LIMIT, MARKET - LIMIT
+        :type type: str (ENUM)
+        :param quantity: required - Order Quantity - 3
+        :type quantity: float
+        :param price: optional - Order Price - 1000
+        :type price: float
+        :param timeInForce: optional - Time in force method（Default GTC) - GTC
+        :type timeInForce: str (ENUM)
+        :param reduceOnly: optional - Reduce Only (Default false) - false
+        :type reduceOnly: bool
+        :param postOnly: optional - Post Only (Default false) - false
+        :type postOnly: bool
+        :param newOrderRespType: optional - "ACK", "RESULT", Default "ACK" - ACK
+        :type newOrderRespType: str (ENUM)
+        :param clientOrderId: optional - User-defined order ID cannot be repeated in pending orders - 10000
+        :type clientOrderId: str
+        :param recvWindow: optional
+        :type recvWindow: int
+
+        """
+        return self._request_options_api('post', 'order', data=params)
+
+    def options_place_batch_order(self, **params):
+        """Place Multiple Option orders (TRADE)
+
+        https://binance-docs.github.io/apidocs/voptions/en/#place-multiple-option-orders-trade
+
+        :param orders: required - order list. Max 5 orders - [{"symbol":"BTC-210115-35000-C","price":"100","quantity":"0.0001","side":"BUY","type":"LIMIT"}]
+        :type orders: list
+        :param recvWindow: optional
+        :type recvWindow: int
+
+        """
+        return self._request_options_api('post', 'batchOrders', data=params)
+
+    def options_cancel_order(self, **params):
+        """Cancel Option order (TRADE)
+
+        https://binance-docs.github.io/apidocs/voptions/en/#cancel-option-order-trade
+
+        :param symbol: required - Option trading pair - BTC-200730-9000-C
+        :type symbol: str
+        :param orderId: optional - Order ID - 4611875134427365377
+        :type orderId: str
+        :param clientOrderId: optional - User-defined order ID - 10000
+        :type clientOrderId: str
+        :param recvWindow: optional
+        :type recvWindow: int
+
+        """
+        return self._request_options_api('delete', 'order', data=params)
+
+    def options_cancel_batch_order(self, **params):
+        """Cancel Multiple Option orders (TRADE)
+
+        https://binance-docs.github.io/apidocs/voptions/en/#cancel-multiple-option-orders-trade
+
+        :param symbol: required - Option trading pair - BTC-200730-9000-C
+        :type symbol: str
+        :param orderIds: optional - Order ID - [4611875134427365377,4611875134427365378]
+        :type orderId: list
+        :param clientOrderIds: optional - User-defined order ID - ["my_id_1","my_id_2"]
+        :type clientOrderIds: list
+        :param recvWindow: optional
+        :type recvWindow: int
+
+        """
+        return self._request_options_api('delete', 'batchOrders', data=params)
+
+    def options_cancel_all_orders(self, **params):
+        """Cancel all Option orders (TRADE)
+
+        https://binance-docs.github.io/apidocs/voptions/en/#cancel-all-option-orders-trade
+
+        :param symbol: required - Option trading pair - BTC-200730-9000-C
+        :type symbol: str
+        :param recvWindow: optional
+        :type recvWindow: int
+
+        """
+        return self._request_options_api('delete', 'allOpenOrders', data=params)
+
+    def options_query_order(self, **params):
+        """Query Option order (TRADE)
+
+        https://binance-docs.github.io/apidocs/voptions/en/#query-option-order-trade
+
+        :param symbol: required - Option trading pair - BTC-200730-9000-C
+        :type symbol: str
+        :param orderId: optional - Order ID - 4611875134427365377
+        :type orderId: str
+        :param clientOrderId: optional - User-defined order ID - 10000
+        :type clientOrderId: str
+        :param recvWindow: optional
+        :type recvWindow: int
+
+        """
+        return self._request_options_api('get', 'order', data=params)
+
+    def options_query_pending_orders(self, **params):
+        """Query current pending Option orders (TRADE)
+
+        https://binance-docs.github.io/apidocs/voptions/en/#query-current-pending-option-orders-trade
+
+        :param symbol: required - Option trading pair - BTC-200730-9000-C
+        :type symbol: str
+        :param orderId: optional - Returns the orderId and subsequent orders, the most recent order is returned by default - 100000
+        :type orderId: str
+        :param startTime: optional - Start Time - 1593511200000
+        :type startTime: int
+        :param endTime: optional - End Time - 1593511200000
+        :type endTime: int
+        :param limit: optional - Number of result sets returned Default:100 Max:1000 - 100
+        :type limit: int
+        :param recvWindow: optional
+        :type recvWindow: int
+
+        """
+        return self._request_options_api('get', 'openOrders', data=params)
+
+    def options_query_order_history(self, **params):
+        """Query Option order history (TRADE)
+
+        https://binance-docs.github.io/apidocs/voptions/en/#query-option-order-history-trade
+
+        :param symbol: required - Option trading pair - BTC-200730-9000-C
+        :type symbol: str
+        :param orderId: optional - Returns the orderId and subsequent orders, the most recent order is returned by default - 100000
+        :type orderId: str
+        :param startTime: optional - Start Time - 1593511200000
+        :type startTime: int
+        :param endTime: optional - End Time - 1593511200000
+        :type endTime: int
+        :param limit: optional - Number of result sets returned Default:100 Max:1000 - 100
+        :type limit: int
+        :param recvWindow: optional
+        :type recvWindow: int
+
+        """
+        return self._request_options_api('get', 'historyOrders', data=params)

--- a/binance/client.py
+++ b/binance/client.py
@@ -6008,7 +6008,7 @@ class Client(object):
         :type recvWindow: int
 
         """
-        return self._request_options_api('get', 'account', data=params)
+        return self._request_options_api('get', 'account', signed=True, data=params)
 
     def options_funds_transfer(self, **params):
         """Funds transfer (USER_DATA)
@@ -6025,7 +6025,7 @@ class Client(object):
         :type recvWindow: int
 
         """
-        return self._request_options_api('post', 'transfer', data=params)
+        return self._request_options_api('post', 'transfer', signed=True, data=params)
 
     def options_positions(self, **params):
         """Option holdings info (USER_DATA)
@@ -6038,7 +6038,7 @@ class Client(object):
         :type recvWindow: int
 
         """
-        return self._request_options_api('get', 'position', data=params)
+        return self._request_options_api('get', 'position', signed=True, data=params)
 
     def options_bill(self, **params):
         """Account funding flow (USER_DATA)
@@ -6059,7 +6059,7 @@ class Client(object):
         :type recvWindow: int
 
         """
-        return self._request_options_api('post', 'bill', data=params)
+        return self._request_options_api('post', 'bill', signed=True, data=params)
 
     def options_place_order(self, **params):
         """Option order (TRADE)
@@ -6090,7 +6090,7 @@ class Client(object):
         :type recvWindow: int
 
         """
-        return self._request_options_api('post', 'order', data=params)
+        return self._request_options_api('post', 'order', signed=True, data=params)
 
     def options_place_batch_order(self, **params):
         """Place Multiple Option orders (TRADE)
@@ -6103,7 +6103,7 @@ class Client(object):
         :type recvWindow: int
 
         """
-        return self._request_options_api('post', 'batchOrders', data=params)
+        return self._request_options_api('post', 'batchOrders', signed=True, data=params)
 
     def options_cancel_order(self, **params):
         """Cancel Option order (TRADE)
@@ -6120,7 +6120,7 @@ class Client(object):
         :type recvWindow: int
 
         """
-        return self._request_options_api('delete', 'order', data=params)
+        return self._request_options_api('delete', 'order', signed=True, data=params)
 
     def options_cancel_batch_order(self, **params):
         """Cancel Multiple Option orders (TRADE)
@@ -6137,7 +6137,7 @@ class Client(object):
         :type recvWindow: int
 
         """
-        return self._request_options_api('delete', 'batchOrders', data=params)
+        return self._request_options_api('delete', 'batchOrders', signed=True, data=params)
 
     def options_cancel_all_orders(self, **params):
         """Cancel all Option orders (TRADE)
@@ -6150,7 +6150,7 @@ class Client(object):
         :type recvWindow: int
 
         """
-        return self._request_options_api('delete', 'allOpenOrders', data=params)
+        return self._request_options_api('delete', 'allOpenOrders', signed=True, data=params)
 
     def options_query_order(self, **params):
         """Query Option order (TRADE)
@@ -6167,7 +6167,7 @@ class Client(object):
         :type recvWindow: int
 
         """
-        return self._request_options_api('get', 'order', data=params)
+        return self._request_options_api('get', 'order', signed=True, data=params)
 
     def options_query_pending_orders(self, **params):
         """Query current pending Option orders (TRADE)
@@ -6188,7 +6188,7 @@ class Client(object):
         :type recvWindow: int
 
         """
-        return self._request_options_api('get', 'openOrders', data=params)
+        return self._request_options_api('get', 'openOrders', signed=True, data=params)
 
     def options_query_order_history(self, **params):
         """Query Option order history (TRADE)
@@ -6209,4 +6209,4 @@ class Client(object):
         :type recvWindow: int
 
         """
-        return self._request_options_api('get', 'historyOrders', data=params)
+        return self._request_options_api('get', 'historyOrders', signed=True, data=params)

--- a/binance/client.py
+++ b/binance/client.py
@@ -282,6 +282,11 @@ class Client(object):
 
         return self._request(method, uri, signed, True, **kwargs)
 
+    def _request_options_api(self, method, path, signed=False, **kwargs):
+        uri = self._create_options_api_uri(path)
+
+        return self._request(method, uri, signed, True, **kwargs)
+
     def _handle_response(self):
         """Internal helper for handling API responses from the Binance server.
         Raises the appropriate exceptions when necessary; otherwise, returns the

--- a/binance/client.py
+++ b/binance/client.py
@@ -5856,7 +5856,12 @@ class Client(object):
         """
         return self._request_margin_api('post', 'enableFastWithdrawSwitch', True, data=params)
 
-    # Options API
+    """
+    ====================================================================================================================
+    Options API
+    ====================================================================================================================
+    """
+    # Quoting interface endpoints
 
     def options_ping(self):
         """Test connectivity to the REST API
@@ -5865,3 +5870,120 @@ class Client(object):
 
         """
         return self._request_options_api('get', 'ping')
+
+    def options_time(self):
+        """Get server time
+
+        https://binance-docs.github.io/apidocs/voptions/en/#get-server-time
+
+        """
+        return self._request_options_api('get', 'time')
+
+    def options_info(self):
+        """Get current trading pair info
+
+        https://binance-docs.github.io/apidocs/voptions/en/#get-current-trading-pair-info
+
+        """
+        return self._request_options_api('get', 'optionInfo')
+
+    def options_exchange_info(self):
+        """Get current limit info and trading pair info
+
+        https://binance-docs.github.io/apidocs/voptions/en/#get-current-limit-info-and-trading-pair-info
+
+        """
+        return self._request_options_api('get', 'exchangeInfo')
+
+    def options_index_price(self, **params):
+        """Get the spot index price
+
+        https://binance-docs.github.io/apidocs/voptions/en/#get-the-spot-index-price
+
+        :param underlying: mandatory - Spot pair（Option contract underlying asset）- BTCUSDT
+        :type underlying: str
+
+        """
+        return self._request_options_api('get', 'index', data=params)
+
+    def options_price(self, **params):
+        """Get the latest price
+
+        https://binance-docs.github.io/apidocs/voptions/en/#get-the-latest-price
+
+        :param symbol: optional - Option trading pair - BTC-200730-9000-C
+        :type symbol: str
+
+        """
+        return self._request_options_api('get', 'ticker', data=params)
+
+    def options_mark_price(self, **params):
+        """Get the latest mark price
+
+        https://binance-docs.github.io/apidocs/voptions/en/#get-the-latest-mark-price
+
+        :param symbol: optional - Option trading pair - BTC-200730-9000-C
+        :type symbol: str
+
+        """
+        return self._request_options_api('get', 'mark', data=params)
+
+    def options_depth(self, **params):
+        """Depth information
+
+        https://binance-docs.github.io/apidocs/voptions/en/#depth-information
+
+        :param symbol: mandatory - Option trading pair - BTC-200730-9000-C
+        :type symbol: str
+        :param limit: optional - Default:100 Max:1000.Optional value:[10, 20, 50, 100, 500, 1000] - 100
+        :type limit: int
+
+        """
+        return self._request_options_api('get', 'depth', data=params)
+
+    def options_klines(self, **params):
+        """Candle data
+
+        https://binance-docs.github.io/apidocs/voptions/en/#candle-data
+
+        :param symbol: mandatory - Option trading pair - BTC-200730-9000-C
+        :type symbol: str
+        :param interval: mandatory - Time interval - 5m
+        :type interval: str
+        :param startTime: optional - Start Time - 1592317127349
+        :type startTime: int
+        :param endTime: optional - End Time - 1592317127349
+        :type endTime: int
+        :param limit: optional - Number of records Default:500 Max:1500 - 500
+        :type limit: int
+
+        """
+        return self._request_options_api('get', 'klines', data=params)
+
+    def options_recent_trades(self, **params):
+        """Recently completed Option trades
+
+        https://binance-docs.github.io/apidocs/voptions/en/#recently-completed-option-trades
+
+        :param symbol: mandatory - Option trading pair - BTC-200730-9000-C
+        :type symbol: str
+        :param limit: optional - Number of records Default:100 Max:500 - 100
+        :type limit: int
+
+        """
+        return self._request_options_api('get', 'trades', data=params)
+
+    def options_historical_trades(self, **params):
+        """Query trade history
+
+        https://binance-docs.github.io/apidocs/voptions/en/#query-trade-history
+
+        :param symbol: mandatory - Option trading pair - BTC-200730-9000-C
+        :type symbol: str
+        :param fromId: optional - The deal ID from which to return. The latest deal record is returned by default - 1592317127349
+        :type fromId: int
+        :param limit: optional - Number of records Default:100 Max:500 - 100
+        :type limit: int
+
+        """
+        return self._request_options_api('get', 'historicalTrades', data=params)

--- a/binance/client.py
+++ b/binance/client.py
@@ -5928,7 +5928,7 @@ class Client(object):
         """
         return self._request_options_api('get', 'mark', data=params)
 
-    def options_depth(self, **params):
+    def options_order_book(self, **params):
         """Depth information
 
         https://binance-docs.github.io/apidocs/voptions/en/#depth-information

--- a/binance/client.py
+++ b/binance/client.py
@@ -5900,7 +5900,7 @@ class Client(object):
 
         https://binance-docs.github.io/apidocs/voptions/en/#get-the-spot-index-price
 
-        :param underlying: mandatory - Spot pair（Option contract underlying asset）- BTCUSDT
+        :param underlying: required - Spot pair（Option contract underlying asset）- BTCUSDT
         :type underlying: str
 
         """
@@ -5933,7 +5933,7 @@ class Client(object):
 
         https://binance-docs.github.io/apidocs/voptions/en/#depth-information
 
-        :param symbol: mandatory - Option trading pair - BTC-200730-9000-C
+        :param symbol: required - Option trading pair - BTC-200730-9000-C
         :type symbol: str
         :param limit: optional - Default:100 Max:1000.Optional value:[10, 20, 50, 100, 500, 1000] - 100
         :type limit: int
@@ -5946,9 +5946,9 @@ class Client(object):
 
         https://binance-docs.github.io/apidocs/voptions/en/#candle-data
 
-        :param symbol: mandatory - Option trading pair - BTC-200730-9000-C
+        :param symbol: required - Option trading pair - BTC-200730-9000-C
         :type symbol: str
-        :param interval: mandatory - Time interval - 5m
+        :param interval: required - Time interval - 5m
         :type interval: str
         :param startTime: optional - Start Time - 1592317127349
         :type startTime: int
@@ -5965,7 +5965,7 @@ class Client(object):
 
         https://binance-docs.github.io/apidocs/voptions/en/#recently-completed-option-trades
 
-        :param symbol: mandatory - Option trading pair - BTC-200730-9000-C
+        :param symbol: required - Option trading pair - BTC-200730-9000-C
         :type symbol: str
         :param limit: optional - Number of records Default:100 Max:500 - 100
         :type limit: int
@@ -5978,7 +5978,7 @@ class Client(object):
 
         https://binance-docs.github.io/apidocs/voptions/en/#query-trade-history
 
-        :param symbol: mandatory - Option trading pair - BTC-200730-9000-C
+        :param symbol: required - Option trading pair - BTC-200730-9000-C
         :type symbol: str
         :param fromId: optional - The deal ID from which to return. The latest deal record is returned by default - 1592317127349
         :type fromId: int

--- a/binance/client.py
+++ b/binance/client.py
@@ -5855,3 +5855,13 @@ class Client(object):
 
         """
         return self._request_margin_api('post', 'enableFastWithdrawSwitch', True, data=params)
+
+    # Options API
+
+    def options_ping(self):
+        """Test connectivity to the REST API
+
+        https://binance-docs.github.io/apidocs/voptions/en/#test-connectivity
+
+        """
+        return self._request_options_api('get', 'ping')

--- a/binance/client.py
+++ b/binance/client.py
@@ -171,6 +171,9 @@ class Client(object):
     def _create_futures_coin_data_api_url(self, path, version=1):
         return self.FUTURES_COIN_DATA_URL + "/" + path
 
+    def _create_options_api_uri(self, path):
+        return self.OPTIONS_URL + '/' + self.OPTIONS_API_VERSION + '/' + path
+
     def _generate_signature(self, data):
 
         ordered_data = self._order_params(data)

--- a/binance/client.py
+++ b/binance/client.py
@@ -5864,7 +5864,7 @@ class Client(object):
     # Quoting interface endpoints
 
     def options_ping(self):
-        """Test connectivity to the REST API
+        """Test connectivity
 
         https://binance-docs.github.io/apidocs/voptions/en/#test-connectivity
 

--- a/binance/websockets.py
+++ b/binance/websockets.py
@@ -665,6 +665,29 @@ class BinanceSocketManager(threading.Thread):
         stream_path = 'streams={}'.format('/'.join(streams))
         return self._start_socket(stream_path, callback, 'stream?')
 
+    def start_options_multiplex_socket(self, streams, callback):
+        """Start a multiplexed socket using a list of socket names.
+        User stream sockets can not be included.
+
+        Symbols in socket name must be lowercase i.e bnbbtc@aggTrade, neobtc@ticker
+
+        Combined stream events are wrapped as follows: {"stream":"<streamName>","data":<rawPayload>}
+
+        https://binance-docs.github.io/apidocs/voptions/en/#account-and-trading-interface
+
+        :param streams: list of stream names in lower case
+        :type streams: list
+        :param callback: callback function to handle messages
+        :type callback: function
+
+        :returns: connection key string if successful, False otherwise
+
+        Message Format - see Binance API docs for all types
+
+        """
+        stream_path = 'streams={}'.format('/'.join([s.lower() for s in streams]))
+        return self._start_options_socket(stream_path, callback, 'stream?')
+
     def start_user_socket(self, callback):
         """Start a websocket for user data
 

--- a/binance/websockets.py
+++ b/binance/websockets.py
@@ -72,6 +72,7 @@ class BinanceSocketManager(threading.Thread):
     STREAM_URL = 'wss://stream.binance.com:9443/'
     FSTREAM_URL = 'wss://fstream.binance.com/'
     VSTREAM_URL = 'wss://vstream.binance.com/'
+    VSTREAM_TESTNET_URL = 'wss://testnetws.binanceops.com/'
 
     WEBSOCKET_DEPTH_5 = '5'
     WEBSOCKET_DEPTH_10 = '10'
@@ -96,6 +97,8 @@ class BinanceSocketManager(threading.Thread):
         self._listen_keys = {'user': None, 'margin': None}
         self._account_callbacks = {'user': None, 'margin': None}
         # Isolated margin sockets will be opened under the 'symbol' name
+
+        self.testnet = self._client.testnet
 
     def _start_socket(self, path, callback, prefix='ws/'):
         if path in self._conns:
@@ -132,7 +135,12 @@ class BinanceSocketManager(threading.Thread):
         if path in self._conns:
             return False
 
-        factory_url = self.VSTREAM_URL + prefix + path
+        if self.testnet:
+            url = self.VSTREAM_TESTNET_URL
+        else:
+            url = self.VSTREAM_URL
+
+        factory_url = url + prefix + path
         factory = BinanceClientFactory(factory_url)
         factory.protocol = BinanceClientProtocol
         factory.callback = callback

--- a/binance/websockets.py
+++ b/binance/websockets.py
@@ -28,6 +28,7 @@ class BinanceClientProtocol(WebSocketClientProtocol):
                 payload = gzip.decompress(payload)
             except:
                 print('Could not interpret binary response payload')
+                return
 
         try:
             payload_obj = json.loads(payload.decode('utf8'))

--- a/docs/depth_cache.rst
+++ b/docs/depth_cache.rst
@@ -1,7 +1,8 @@
 Depth Cache
 ===========
 
-To follow the depth cache updates for a symbol use the `DepthCacheManager`
+To follow the depth cache updates for a symbol use the `DepthCacheManager`. For vanilla options use the
+`OptionsDepthCacheManager`.
 
 Create the manager like so, passing the api client, symbol and an optional callback function.
 


### PR DESCRIPTION
Implements support for Binance's new vanilla options product. Their API documentation can be found [here](https://binance-docs.github.io/apidocs/voptions/en/#general-info).

This PR adds all the current REST endpoints, websockets for vanilla options and an OptionsDepthCacheManager. It also adds vanilla options testnet support in both REST and websockets however I have been unable to fully verify the websocket implementation as there has been no activity on the testnet platform. It does make a successful connection however so probably would work.