### PR TITLE
Fixing problem with not passing end_str for historical_klines

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -870,7 +870,7 @@ class Client(object):
         :return: list of OHLCV values
 
         """
-        return self._historical_klines(symbol, interval, start_str, end_str=end_str, limit=500, spot=True)
+        return self._historical_klines(symbol, interval, start_str, end_str=end_str, limit=limit, spot=True)
 
     def _historical_klines(self, symbol, interval, start_str, end_str=None,
                            limit=500, spot=True):

--- a/binance/client.py
+++ b/binance/client.py
@@ -870,7 +870,7 @@ class Client(object):
         :return: list of OHLCV values
 
         """
-        return self._historical_klines(symbol, interval, start_str, end_str=None, limit=500, spot=True)
+        return self._historical_klines(symbol, interval, start_str, end_str=end_str, limit=500, spot=True)
 
     def _historical_klines(self, symbol, interval, start_str, end_str=None,
                            limit=500, spot=True):


### PR DESCRIPTION
I was testing out historical klines and it seemed like `end_str` was never being respected in regards to the request. Ended up taking a look at the code and saw that `end_str` was always set to `None` and so was never used. Would appreciate this getting merged and released with the next version as the workaround is rather messy. Thanks! 