### PR TITLE
fix get_historical_klines parameters call

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -870,7 +870,7 @@ class Client(object):
         :return: list of OHLCV values
 
         """
-        return self._historical_klines(symbol, interval, start_str, end_str=None, limit=500, spot=True)
+        return self._historical_klines(symbol, interval, start_str, end_str, limit, spot=True)
 
     def _historical_klines(self, symbol, interval, start_str, end_str=None,
                            limit=500, spot=True):


### PR DESCRIPTION
This commit fixes the ignore of end_str and limit parameters call in the _historical_klines call.

They were ignored and the default was internally passed.