### PR TITLE
Wrapper function should use parameters

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -870,7 +870,7 @@ class Client(object):
         :return: list of OHLCV values
 
         """
-        return self._historical_klines(symbol, interval, start_str, end_str=None, limit=500, spot=True)
+        return self._historical_klines(symbol, interval, start_str, end_str=end_str, limit=limit, spot=True)
 
     def _historical_klines(self, symbol, interval, start_str, end_str=None,
                            limit=500, spot=True):


### PR DESCRIPTION
Having get_historical_klines(...) taking in parameters while not using them and passing down fixed values to _historical_klines(...) disallows users to change the behaviour of the function and it's frustrating to debug.