### PR TITLE
get_historical_klines(..) errors on far back time

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -924,6 +924,9 @@ class Client(object):
                 end_ts = end_str
             else:
                 end_ts = date_to_milliseconds(end_str)
+		
+	    if end_str <= start_ts:
+                return []
 
         idx = 0
         while True:


### PR DESCRIPTION
When PR #798 is applied, will get the error `binance.exceptions.BinanceAPIException: APIError(code=-1023): Start time is greater than end time` for calling the function with timestamps very far back (eg. start_str=<1000 days ago> and end_str=<999 days ago>)

Not sure if the function should actually throw something out or return empty list. The change I made returns empty list for the same cases and also when end_str has wrong value.

Here's the snippet to generate the error after PR #798 
```
from datetime import datetime
from binance.client import Client

def TimestampMillisec64():
    return int((datetime.utcnow() - datetime(1970, 1, 1)).total_seconds() * 1000)

api_key = ''
api_secret = ''

SEC = 1000
MIN = SEC*60
HOUR = MIN*60
DAY = HOUR*24

client = Client(api_key, api_secret)
result = client.get_all_orders(symbol='BNBBTC', requests_params={'timeout': 5})
start_time = TimestampMillisec64()-DAY*1000
end_time = TimestampMillisec64()-DAY*999
result = client.get_historical_klines('BTCUSDT', '1m', start_time, end_str=end_time, limit=500)
```
