### PR TITLE
Undo conversion params to strings, to fix delete None params.

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -215,7 +215,7 @@ class BaseClient:
             if key == 'signature':
                 has_signature = True
             else:
-                params.append((key, str(value)))
+                params.append((key, value))
         # sort parameters by key
         params.sort(key=itemgetter(0))
         if has_signature:


### PR DESCRIPTION
When we pass `symbol=None` to `get_ticker`, and after executing the `_order_params` method, 
the **kwargs** changes from `{'data': {'symbol': None}, 'timeout': 10}` to 
`{'data': {'symbol': 'None'}, 'timeout': 10}`, which makes **null_args** not work as expected.

We need to undo the conversion or use the following way to get null_args, which may not be very elegant.

`null_args = [i for i, (key, value) in enumerate(kwargs['data']) if value == 'None']`

