### PR TITLE
Fix def withdraw_history_id, "withdrawId" key does not exist in binance output

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -2640,7 +2640,7 @@ class Client(BaseClient):
         """
         result = self.get_withdraw_history(**params)
 
-        for entry in result['withdrawList']:
+        for entry in result:
             if 'id' in entry and entry['id'] == withdraw_id:
                 return entry
 


### PR DESCRIPTION
Fix def_withdraw_history_id, "withdrawId" key does not exist in binance output

When calling get_withdraw_history_id, the following exception was being thrown:
 line 2644, in get_withdraw_history_id
    for entry in result['withdrawList']:
TypeError: list indices must be integers or slices, not str

It seems that there is no ["withdrawList"] in the result, existing, just removed it