### PR TITLE
Allow requests_params to be set for unsigned requests

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -256,16 +256,16 @@ class BaseClient:
         if data and isinstance(data, dict):
             kwargs['data'] = data
 
-        if signed:
-            # generate signature
-            kwargs['data']['timestamp'] = int(time.time() * 1000 + self.timestamp_offset)
-            kwargs['data']['signature'] = self._generate_signature(kwargs['data'])
-
             # find any requests params passed and apply them
             if 'requests_params' in kwargs['data']:
                 # merge requests params into kwargs
                 kwargs.update(kwargs['data']['requests_params'])
                 del(kwargs['data']['requests_params'])
+
+        if signed:
+            # generate signature
+            kwargs['data']['timestamp'] = int(time.time() * 1000 + self.timestamp_offset)
+            kwargs['data']['signature'] = self._generate_signature(kwargs['data'])
 
         # sort get and post params to match signature order
         if data:


### PR DESCRIPTION
Due to change https://github.com/sammchardy/python-binance/commit/eb790b389ccb0956d9ec1410103125e6f6a7cccd, it was not possible for unsigned requests to make use of the `requests_params` kwarg.

This PR fixes this bug.