### PR TITLE
docs: Remove warning of openInterest in Endpoint.md

### DIFF
--- a/Endpoints.md
+++ b/Endpoints.md
@@ -617,7 +617,6 @@
     client.futures_liquidation_orders(symbol, startTime, endTime, limit)
     ``` 
   - **GET /fapi/v1/openInterest** (Get present open interest of a specific symbol.)
-    > :warning: Probably broken, python code below is implemented on v1/openInterest endpoint.
     ```python 
     client.futures_open_interest(symbol)
     ``` 


### PR DESCRIPTION
Delete the warnings of `openInterest` in Endpoints.md doc file, because now the function is working fine.

Related pull requests: #884