### PR TITLE
closing connection when client is deleted

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -6452,6 +6452,13 @@ class Client(BaseClient):
         """
         return self._request_options_api('get', 'userTrades', signed=True, data=params)
 
+    def close_connection(self):
+        if self.session:
+            self.session.close()
+
+    def __del__(self):
+        self.close_connection()
+
 
 class AsyncClient(BaseClient):
 


### PR DESCRIPTION
connection to binance should be closed when a client is deleted (garbage collected). If we do not close the connection a resource warning like the following will be thrown (esp. in unittest) :
```
ResourceWarning: unclosed <ssl.SSLSocket fd=21, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('192.168.6.6', 40258), raddr=('52.84.150.34', 443)>
```