### PR TITLE
hotfix: 修复websocket异常断开后不报异常不重联的bug

### DIFF
--- a/binance/streams.py
+++ b/binance/streams.py
@@ -76,7 +76,7 @@ class ReconnectingWebsocket:
         assert self._path
         self.ws_state = WSListenerState.STREAMING
         ws_url = self._url + self._prefix + self._path
-        self._conn = ws.connect(ws_url, timeout=1)
+        self._conn = ws.connect(ws_url, close_timeout=0.1)
         try:
             self.ws = await self._conn.__aenter__()
         except:  # noqa


### PR DESCRIPTION
## 重现方式
- 建立一个websocket，断开网络
- websocket不会抛出异常，同时不会尝试重联

## 修复
- 修复异常导致的websocket断开后不回去重联的问题