### PR TITLE
fix connection interrupt/disconnect issue

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -6534,6 +6534,12 @@ class AsyncClient(BaseClient):
 
         kwargs = self._get_request_kwargs(method, signed, force_params, **kwargs)
 
+         # checks if there is still a connection to binance before sending request and crashing
+        while True:
+            test = getattr(self.session, method)(uri, **kwargs) 
+            if test.status_code == 200:
+                break
+                
         async with getattr(self.session, method)(uri, **kwargs) as response:
             self.response = response
             return await self._handle_response(response)


### PR DESCRIPTION
when the network has an interruption or short disconnection this will save the program from crashing immediately altough a sleep might be required  in between calls to make sure it does not cause an api ban
initial fix for this can be found here
https://github.com/sammchardy/python-binance/issues/955