### PR TITLE
Long short ratio API implementation

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -5762,30 +5762,6 @@ class Client(BaseClient):
         """
         return self._request_futures_api('get', 'adlQuantile', signed=True, data=params)
 
-    def futures_top_longshort_account_ratio(self, **params):
-        """Get present long to short ratio for top accounts of a specific symbol.
-
-        https://binance-docs.github.io/apidocs/futures/en/#top-trader-long-short-ratio-accounts-market_data
-
-        """
-        return self._request_futures_api('get', 'topLongShortAccountRatio', data=params)
-
-    def futures_top_longshort_position_ratio(self, **params):
-        """Get present long to short ratio for top positions of a specific symbol.
-
-        https://binance-docs.github.io/apidocs/futures/en/#top-trader-long-short-ratio-positions
-
-        """
-        return self._request_futures_api('get', 'topLongShortPositionRatio', data=params)
-
-    def futures_global_longshort_ratio(self, **params):
-        """Get present global long to short ratio of a specific symbol.
-
-        https://binance-docs.github.io/apidocs/futures/en/#long-short-ratio
-
-        """
-        return self._request_futures_api('get', 'globalLongShortAccountRatio', data=params)
-
     def futures_open_interest(self, **params):
         """Get present open interest of a specific symbol.
 

--- a/binance/client.py
+++ b/binance/client.py
@@ -5706,21 +5706,21 @@ class Client(BaseClient):
         
         https://binance-docs.github.io/apidocs/futures/en/#top-trader-long-short-ratio-accounts-market_data
         """
-        return self._request_futures_api('get', 'topLongShortAccountRatio', data=params)
+        return self._request_futures_data_api('get', 'topLongShortAccountRatio', data=params)
     
     def futures_top_longshort_position_ratio(self, **params):
         """Get present long to short ratio for top positions of a specific symbol.
         
         https://binance-docs.github.io/apidocs/futures/en/#top-trader-long-short-ratio-positions
         """
-        return self._request_futures_api('get', 'topLongShortPositionRatio', data=params)
+        return self._request_futures_data_api('get', 'topLongShortPositionRatio', data=params)
     
     def futures_global_longshort_ratio(self, **params):
         """Get present global long to short ratio of a specific symbol.
         
         https://binance-docs.github.io/apidocs/futures/en/#long-short-ratio
         """
-        return self._request_futures_api('get', 'globalLongShortAccountRatio', data=params)
+        return self._request_futures_data_api('get', 'globalLongShortAccountRatio', data=params)
 
     def futures_ticker(self, **params):
         """24 hour rolling window price change statistics.

--- a/binance/client.py
+++ b/binance/client.py
@@ -5702,28 +5702,25 @@ class Client(BaseClient):
         return self._request_futures_api('get', 'fundingRate', data=params)
 
     def futures_top_longshort_account_ratio(self, **params):
-	"""Get present long to short ratio for top accounts of a specific symbol.
-
-	https://binance-docs.github.io/apidocs/futures/en/#top-trader-long-short-ratio-accounts-market_data
-
-	"""
-	return self._request_futures_api('get', 'topLongShortAccountRatio', data=params)
-
+        """Get present long to short ratio for top accounts of a specific symbol.
+        
+        https://binance-docs.github.io/apidocs/futures/en/#top-trader-long-short-ratio-accounts-market_data
+        """
+        return self._request_futures_api('get', 'topLongShortAccountRatio', data=params)
+    
     def futures_top_longshort_position_ratio(self, **params):
-            """Get present long to short ratio for top positions of a specific symbol.
-
-            https://binance-docs.github.io/apidocs/futures/en/#top-trader-long-short-ratio-positions
-
-            """
-            return self._request_futures_api('get', 'topLongShortPositionRatio', data=params)
-
+        """Get present long to short ratio for top positions of a specific symbol.
+        
+        https://binance-docs.github.io/apidocs/futures/en/#top-trader-long-short-ratio-positions
+        """
+        return self._request_futures_api('get', 'topLongShortPositionRatio', data=params)
+    
     def futures_global_longshort_ratio(self, **params):
-            """Get present global long to short ratio of a specific symbol.
-
-            https://binance-docs.github.io/apidocs/futures/en/#long-short-ratio
-
-            """
-            return self._request_futures_api('get', 'globalLongShortAccountRatio', data=params)
+        """Get present global long to short ratio of a specific symbol.
+        
+        https://binance-docs.github.io/apidocs/futures/en/#long-short-ratio
+        """
+        return self._request_futures_api('get', 'globalLongShortAccountRatio', data=params)
 
     def futures_ticker(self, **params):
         """24 hour rolling window price change statistics.

--- a/binance/client.py
+++ b/binance/client.py
@@ -5701,6 +5701,30 @@ class Client(BaseClient):
         """
         return self._request_futures_api('get', 'fundingRate', data=params)
 
+    def futures_top_longshort_account_ratio(self, **params):
+	"""Get present long to short ratio for top accounts of a specific symbol.
+
+	https://binance-docs.github.io/apidocs/futures/en/#top-trader-long-short-ratio-accounts-market_data
+
+	"""
+	return self._request_futures_api('get', 'topLongShortAccountRatio', data=params)
+
+    def futures_top_longshort_position_ratio(self, **params):
+            """Get present long to short ratio for top positions of a specific symbol.
+
+            https://binance-docs.github.io/apidocs/futures/en/#top-trader-long-short-ratio-positions
+
+            """
+            return self._request_futures_api('get', 'topLongShortPositionRatio', data=params)
+
+    def futures_global_longshort_ratio(self, **params):
+            """Get present global long to short ratio of a specific symbol.
+
+            https://binance-docs.github.io/apidocs/futures/en/#long-short-ratio
+
+            """
+            return self._request_futures_api('get', 'globalLongShortAccountRatio', data=params)
+
     def futures_ticker(self, **params):
         """24 hour rolling window price change statistics.
 
@@ -5740,6 +5764,30 @@ class Client(BaseClient):
 
         """
         return self._request_futures_api('get', 'adlQuantile', signed=True, data=params)
+
+    def futures_top_longshort_account_ratio(self, **params):
+        """Get present long to short ratio for top accounts of a specific symbol.
+
+        https://binance-docs.github.io/apidocs/futures/en/#top-trader-long-short-ratio-accounts-market_data
+
+        """
+        return self._request_futures_api('get', 'topLongShortAccountRatio', data=params)
+
+    def futures_top_longshort_position_ratio(self, **params):
+        """Get present long to short ratio for top positions of a specific symbol.
+
+        https://binance-docs.github.io/apidocs/futures/en/#top-trader-long-short-ratio-positions
+
+        """
+        return self._request_futures_api('get', 'topLongShortPositionRatio', data=params)
+
+    def futures_global_longshort_ratio(self, **params):
+        """Get present global long to short ratio of a specific symbol.
+
+        https://binance-docs.github.io/apidocs/futures/en/#long-short-ratio
+
+        """
+        return self._request_futures_api('get', 'globalLongShortAccountRatio', data=params)
 
     def futures_open_interest(self, **params):
         """Get present open interest of a specific symbol.


### PR DESCRIPTION
3 of the endpoints that are not yet implemented in the library include:

1. /futures/data/globalLongShortAccountRatio
2. /futures/data/topLongShortPositionRatio
3. /futures/data/takerlongshortRatio

I've added the 3 corresponding functions in the client.


I'm not yet very familiar with the package but I tried to run a small test on the futures_global_longshort_ratio and I got an error:

`binance.exceptions.BinanceAPIException: APIError(code=0): Invalid JSON error message from Binance: <!DOCTYPE html>
`

The code that generated that error was:
`client.futures_global_longshort_ratio(symbol='BNBUSDT')
`


Please help me fixing it so we can merge the code.