### PR TITLE
Fix start_kline_futures_socket issue #1040

### DIFF
--- a/binance/streams.py
+++ b/binance/streams.py
@@ -559,8 +559,8 @@ class BinanceSocketManager:
             <pair>_<contractType>@continuousKline_<interval>
         """
 
-        path = f'{symbol.lower()}_{contract_type}@continuousKline_{interval}'
-        return self._get_futures_socket(path, futures_type=futures_type)
+        path = f'{symbol.lower()}_{contract_type.value}@continuousKline_{interval}'
+        return self._get_futures_socket(path, prefix='ws/', futures_type=futures_type)
 
     def miniticker_socket(self, update_time: int = 1000):
         """Start a miniticker websocket for all trades
@@ -1232,8 +1232,8 @@ class ThreadedWebsocketManager(ThreadedApiManager):
             params={
                 'symbol': symbol,
                 'interval': interval,
-                'futures_type': futures_type.value,
-                'contract_type': contract_type.value
+                'futures_type': futures_type,
+                'contract_type': contract_type
             }
         )
 


### PR DESCRIPTION
1. Updated the path for kline_futures_socket to get the contract_type.value.  Use prefix = 'ws/'

2. Updated start_kline_futures_socket not to pass the enum values but the enum themselves.

Tested with below codes:

```
import time
from datetime import datetime

from binance import ThreadedWebsocketManager, AsyncClient
from binance.enums import FuturesType, ContractType

def main():

    twm = ThreadedWebsocketManager()
    twm.start()

    def handle_multiplex_socket_message(msg):
        print(str(msg))

    def handle_socket_message(msg):
        print(str(msg))

    twm.start_kline_socket(callback=handle_socket_message, symbol='XLMUSDT')
    twm.start_multiplex_socket(callback=handle_multiplex_socket_message, streams=['galausdt@kline_1m'])
    twm.start_futures_multiplex_socket(callback=handle_multiplex_socket_message, streams=['btcusdt_perpetual@continuousKline_1m','adausdt_perpetual@continuousKline_1m'])
    twm.start_kline_futures_socket(callback=handle_socket_message, symbol='IOTAUSDT', interval=AsyncClient.KLINE_INTERVAL_1MINUTE, futures_type=FuturesType.USD_M, contract_type=ContractType.PERPETUAL)

    twm.join()


if __name__ == "__main__":
   main()
```