### PR TITLE
Fix bug in ThreadedDepthCacheManager where self._client==None

### DIFF
--- a/binance/depthcache.py
+++ b/binance/depthcache.py
@@ -429,7 +429,7 @@ class ThreadedDepthCacheManager(ThreadedApiManager):
     ) -> str:
 
         while not self._client:
-            time.sleep(0.1)
+            time.sleep(0.01)
             
         dcm = dcm_class(
             client=self._client,

--- a/binance/depthcache.py
+++ b/binance/depthcache.py
@@ -427,6 +427,10 @@ class ThreadedDepthCacheManager(ThreadedApiManager):
         self, dcm_class, callback: Callable, symbol: str,
         refresh_interval=None, bm=None, limit=10, conv_type=float, **kwargs
     ) -> str:
+
+        while not self._client:
+            time.sleep(0.1)
+            
         dcm = dcm_class(
             client=self._client,
             symbol=symbol,

--- a/binance/streams.py
+++ b/binance/streams.py
@@ -393,7 +393,7 @@ class BinanceSocketManager:
     async def _exit_socket(self, path: str):
         await self._stop_socket(path)
 
-    def depth_socket(self, symbol: str, depth: Optional[str] = None, interval: Optional[int] = 100):
+    def depth_socket(self, symbol: str, depth: Optional[str] = None, interval: Optional[int] = None):
         """Start a websocket for symbol market depth returning either a diff or a partial book
 
         https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md#partial-book-depth-streams

--- a/binance/streams.py
+++ b/binance/streams.py
@@ -393,7 +393,7 @@ class BinanceSocketManager:
     async def _exit_socket(self, path: str):
         await self._stop_socket(path)
 
-    def depth_socket(self, symbol: str, depth: Optional[str] = None, interval: Optional[int] = None):
+    def depth_socket(self, symbol: str, depth: Optional[str] = None, interval: Optional[int] = 100):
         """Start a websocket for symbol market depth returning either a diff or a partial book
 
         https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md#partial-book-depth-streams


### PR DESCRIPTION
Instantiating a ThreadedDepthCacheManager frequently fails due to it having not had time to instantiate an AsyncClient before creating objects that depend on it having been created.

The demo code:

```
from binance import ThreadedDepthCacheManager

def main():

    dcm = ThreadedDepthCacheManager()
    # start is required to initialise its internal loop
    dcm.start()

    def handle_depth_cache(depth_cache):
        print(f"symbol {depth_cache.symbol}")
        print("top 5 bids")
        print(depth_cache.get_bids()[:5])
        print("top 5 asks")
        print(depth_cache.get_asks()[:5])
        print("last update time {}".format(depth_cache.update_time))

    dcm_name = dcm.start_depth_cache(handle_depth_cache, symbol='BNBBTC')

    # multiple depth caches can be started
    dcm_name = dcm.start_depth_cache(handle_depth_cache, symbol='ETHBTC')

    dcm.join()


if __name__ == "__main__":
   main()
```

Results in the following stack trace because client is None:

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-3b49585646ff> in <module>
     16     print("last update time {}".format(depth_cache.update_time))
     17 
---> 18 dcm_name = dcm.start_futures_depth_socket(handle_depth_cache, symbol='btcusdt')
     19 
     20 # multiple depth caches can be started

~/opt/anaconda3/lib/python3.8/site-packages/binance/depthcache.py in start_futures_depth_socket(self, callback, symbol, refresh_interval, bm, limit, conv_type)
    464             self, callback: Callable, symbol: str, refresh_interval=None, bm=None, limit=10, conv_type=float
    465     ) -> str:
--> 466         return self._start_depth_cache(
    467             dcm_class=FuturesDepthCacheManager,
    468             callback=callback,

~/opt/anaconda3/lib/python3.8/site-packages/binance/depthcache.py in _start_depth_cache(self, dcm_class, callback, symbol, refresh_interval, bm, limit, conv_type, **kwargs)
    432         #     time.sleep(0.1)
    433 
--> 434         dcm = dcm_class(
    435             client=self._client,
    436             symbol=symbol,

~/opt/anaconda3/lib/python3.8/site-packages/binance/depthcache.py in __init__(self, client, symbol, loop, refresh_interval, bm, limit, conv_type)
    159         self._limit = limit
    160         self._last_update_id = None
--> 161         self._bm = bm or BinanceSocketManager(self._client, self._loop)
    162         self._refresh_interval = refresh_interval or self.DEFAULT_REFRESH
    163         self._conn_key = None

~/opt/anaconda3/lib/python3.8/site-packages/binance/streams.py in __init__(self, client, loop, user_timeout)
    317 
    318         """
--> 319         self.STREAM_URL = self.STREAM_URL.format(client.tld)
    320         self.FSTREAM_URL = self.FSTREAM_URL.format(client.tld)
    321         self.DSTREAM_URL = self.DSTREAM_URL.format(client.tld)

AttributeError: 'NoneType' object has no attribute 'tld'
```


Fixed by adding a while loop that checks if the client has been instantiated yet (after line 430 in `depthcache.py`) before continuing, as is similarly done in ThreadedWebsocketManager.