### PR TITLE
Fix multiAssetsMargin params

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -6010,7 +6010,7 @@ class Client(BaseClient):
 
         """
         params = {
-            'true' if multiAssetsMargin else 'false'
+            'multiAssetsMargin': 'true' if multiAssetsMargin else 'false'
         }
         return self._request_futures_api('post', 'multiAssetsMargin', True, data=params)
 
@@ -6020,7 +6020,7 @@ class Client(BaseClient):
         https://binance-docs.github.io/apidocs/futures/en/#get-current-multi-assets-mode-user_data
 
         """
-        return self._request_futures_api('get', 'multiAssetsMargin', True)
+        return self._request_futures_api('get', 'multiAssetsMargin', True, data={})
 
     def futures_stream_get_listen_key(self):
         res = self._request_futures_api('post', 'listenKey', signed=False, data={})
@@ -8117,12 +8117,12 @@ class AsyncClient(BaseClient):
 
     async def futures_change_multi_assets_mode(self, multiAssetsMargin: bool):
         params = {
-            'true' if multiAssetsMargin else 'false'
+            'multiAssetsMargin': 'true' if multiAssetsMargin else 'false'
         }
         return await self._request_futures_api('post', 'multiAssetsMargin', True, data=params)
 
     async def futures_get_multi_assets_mode(self):
-        return await self._request_futures_api('get', 'multiAssetsMargin', True)
+        return await self._request_futures_api('get', 'multiAssetsMargin', True, data={})
 
     async def futures_stream_get_listen_key(self):
         res = await self._request_futures_api('post', 'listenKey', signed=False, data={})


### PR DESCRIPTION
`futures_change_multi_assets_mode` method's `params` variable is of type `set`, which will lead to a TypeError here:

```
----> 1 await client.futures_change_multi_assets_mode(multiAssetsMargin=True)

.../site-packages/binance/client.py in futures_change_multi_assets_mode(self, multiAssetsMargin)
   8118             'true' if multiAssetsMargin else 'false'
   8119         }
-> 8120         return await self._request_futures_api('post', 'multiAssetsMargin', True, data=params)
   8121
   8122     async def futures_get_multi_assets_mode(self):

.../site-packages/binance/client.py in _request_futures_api(self, method, path, signed, **kwargs)
   7177         uri = self._create_futures_api_uri(path)
   7178
-> 7179         return await self._request(method, uri, signed, True, **kwargs)
   7180
   7181     async def _request_futures_data_api(self, method, path, signed=False, **kwargs) -> Dict:

.../site-packages/binance/client.py in _request(self, method, uri, signed, force_params, **kwargs)
   7151     async def _request(self, method, uri: str, signed: bool, force_params: bool = False, **kwargs):
   7152
-> 7153         kwargs = self._get_request_kwargs(method, signed, force_params, **kwargs)
   7154
   7155         async with getattr(self.session, method)(uri, **kwargs) as response:

....../site-packages/binance/client.py in _get_request_kwargs(self, method, signed, force_params, **kwargs)
    267         if signed:
    268             # generate signature
--> 269             kwargs['data']['timestamp'] = int(time.time() * 1000 + self.timestamp_offset)
    270             kwargs['data']['signature'] = self._generate_signature(kwargs['data'])
    271

TypeError: 'set' object does not support item assignment

----> 1 client.futures_get_multi_assets_mode()

.../site-packages/binance/client.py in futures_get_multi_assets_mode(self)
   6019
   6020         """
-> 6021         return self._request_futures_api('get', 'multiAssetsMargin', True)
   6022
   6023     def futures_stream_get_listen_key(self):

.../site-packages/binance/client.py in _request_futures_api(self, method, path, signed, **kwargs)
    337         uri = self._create_futures_api_uri(path)
    338
--> 339         return self._request(method, uri, signed, True, **kwargs)
    340
    341     def _request_futures_data_api(self, method, path, signed=False, **kwargs) -> Dict:

.../binance/client.py in _request(self, method, uri, signed, force_params, **kwargs)
    310     def _request(self, method, uri: str, signed: bool, force_params: bool = False, **kwargs):
    311
--> 312         kwargs = self._get_request_kwargs(method, signed, force_params, **kwargs)
    313
    314         self.response = getattr(self.session, method)(uri, **kwargs)

.../site-packages/binance/client.py in _get_request_kwargs(self, method, signed, force_params, **kwargs)
    267         if signed:
    268             # generate signature
--> 269             kwargs['data']['timestamp'] = int(time.time() * 1000 + self.timestamp_offset)
    270             kwargs['data']['signature'] = self._generate_signature(kwargs['data'])
    271

KeyError: 'data'
```

Fixed by set `params` to a real dict with "multiAssetsMargin" as the only key.


On the other hand, `futures_get_multi_assets_mode` method has no `data` argument when calling `self._request_futures_api`, which leads to a `KeyError` in the same place above.  I believe `futures_stream_get_listen_key` method has a correct fix for this.