### PR TITLE
make startTime optional for get_historical_klines()

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -961,11 +961,11 @@ class Client(BaseClient):
         # convert interval to useful value in seconds
         timeframe = interval_to_milliseconds(interval)
         
-        # if an end time was passed convert it
+        # if a start time was passed convert it
         start_ts = convert_ts_str(start_str)
 
         # establish first available start timestamp
-        if start_ts != None:
+        if start_ts is not None:
             first_valid_ts = self._get_earliest_valid_timestamp(symbol, interval, klines_type)
             start_ts = max(start_ts, first_valid_ts)
 

--- a/binance/client.py
+++ b/binance/client.py
@@ -909,7 +909,7 @@ class Client(BaseClient):
         )
         return kline[0][0]
 
-    def get_historical_klines(self, symbol, interval, start_str, end_str=None, limit=500,
+    def get_historical_klines(self, symbol, interval, start_str=None, end_str=None, limit=500,
                               klines_type: HistoricalKlinesType = HistoricalKlinesType.SPOT):
         """Get Historical Klines from Binance
 
@@ -917,7 +917,7 @@ class Client(BaseClient):
         :type symbol: str
         :param interval: Binance Kline interval
         :type interval: str
-        :param start_str: Start date string in UTC format or timestamp in milliseconds
+        :param start_str: optional - start date string in UTC format or timestamp in milliseconds
         :type start_str: str|int
         :param end_str: optional - end date string in UTC format or timestamp in milliseconds (default will fetch everything up to now)
         :type end_str: str|int
@@ -929,9 +929,9 @@ class Client(BaseClient):
         :return: list of OHLCV values
 
         """
-        return self._historical_klines(symbol, interval, start_str, end_str=end_str, limit=limit, klines_type=klines_type)
+        return self._historical_klines(symbol, interval, start_str=start_str, end_str=end_str, limit=limit, klines_type=klines_type)
 
-    def _historical_klines(self, symbol, interval, start_str, end_str=None, limit=500,
+    def _historical_klines(self, symbol, interval, start_str=None, end_str=None, limit=500,
                            klines_type: HistoricalKlinesType = HistoricalKlinesType.SPOT):
         """Get Historical Klines from Binance (spot or futures)
 
@@ -943,7 +943,7 @@ class Client(BaseClient):
         :type symbol: str
         :param interval: Binance Kline interval
         :type interval: str
-        :param start_str: Start date string in UTC format or timestamp in milliseconds
+        :param start_str: optional - start date string in UTC format or timestamp in milliseconds
         :type start_str: str|int
         :param end_str: optional - end date string in UTC format or timestamp in milliseconds (default will fetch everything up to now)
         :type end_str: None|str|int
@@ -960,12 +960,14 @@ class Client(BaseClient):
 
         # convert interval to useful value in seconds
         timeframe = interval_to_milliseconds(interval)
-
+        
+        # if an end time was passed convert it
         start_ts = convert_ts_str(start_str)
 
         # establish first available start timestamp
-        first_valid_ts = self._get_earliest_valid_timestamp(symbol, interval, klines_type)
-        start_ts = max(start_ts, first_valid_ts)
+        if start_ts != None:
+            first_valid_ts = self._get_earliest_valid_timestamp(symbol, interval, klines_type)
+            start_ts = max(start_ts, first_valid_ts)
 
         # if an end time was passed convert it
         end_ts = convert_ts_str(end_str)


### PR DESCRIPTION
According to the API docs, startTime is optional for the endpoint /api/v3/klines
https://binance-docs.github.io/apidocs/spot/en/#kline-candlestick-data

Updating the client method get_historical_klines() to follow the official documentation.

I manually tested the update and was able to send API calls without the start_str parameter