### PR TITLE
better round_step_size function

### DIFF
--- a/binance/helpers.py
+++ b/binance/helpers.py
@@ -60,8 +60,8 @@ def round_step_size(quantity: Union[float, Decimal], step_size: Union[float, Dec
 
     :return: decimal
     """
-    precision: int = int(round(-math.log(step_size, 10), 0))
-    return float(round(quantity, precision))
+    quantity = Decimal(str(quantity))
+    return float(quantity - quantity % Decimal(str(step_size)))
 
 
 def convert_ts_str(ts_str):


### PR DESCRIPTION
original one returns wrong:
```
>>> round_step_size(2.6, 1)
3.0
```

not exactly "wrong" for numbers such as 0.001, it rounds as stated, but you might not have that extra 0.4 coins when creating orders. also it won't work with anything else than powers of 0.1:
```
>>> round_step_size(55.3, 0.2)
55.3
```


this one properly rounds to step size, even with floats such as 0.003:
```

>>> round_step_size(2.6, 1)
2.0

>>> round_step_size(2.6, 0.003)
2.598
```

decided to contribute this after a few hours of floating point nightmare