### PR TITLE
fix futures-get-klines-returns-coroutine-instead-of-result

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -8005,7 +8005,7 @@ class AsyncClient(BaseClient):
         return await self._request_futures_api('get', 'continuousKlines', data=params)
 
     async def futures_historical_klines(self, symbol, interval, start_str, end_str=None, limit=500):
-        return self._historical_klines(symbol, interval, start_str, end_str=end_str, limit=limit, klines_type=HistoricalKlinesType.FUTURES)
+        return await self._historical_klines(symbol, interval, start_str, end_str=end_str, limit=limit, klines_type=HistoricalKlinesType.FUTURES)
 
     async def futures_historical_klines_generator(self, symbol, interval, start_str, end_str=None):
         return self._historical_klines_generator(symbol, interval, start_str, end_str=end_str, klines_type=HistoricalKlinesType.FUTURES)


### PR DESCRIPTION
`============================= test session starts =============================
platform win32 -- Python 3.8.7, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- <venv path>
cachedir: .pytest_cache
rootdir: <root path>, configfile: pytest.ini
plugins: cov-3.0.0, pep8-1.0.6, requests-mock-1.9.3
collecting ... collected 10 items

test_api_request.py::test_invalid_json PASSED                            [ 10%]
test_api_request.py::test_api_exception PASSED                           [ 20%]
test_api_request.py::test_api_exception_invalid_json PASSED              [ 30%]
test_depth_cache.py::test_add_bids PASSED                                [ 40%]
test_depth_cache.py::test_add_asks PASSED                                [ 50%]
test_historical_klines.py::test_exact_amount PASSED                      [ 60%]
test_historical_klines.py::test_start_and_end_str PASSED                 [ 70%]
test_historical_klines.py::test_start_and_end_timestamp PASSED           [ 80%]
test_historical_klines.py::test_historical_kline_generator PASSED        [ 90%]
test_historical_klines.py::test_historical_kline_generator_empty_response PASSED [100%]

============================= 10 passed in 0.87s ==============================

Process finished with exit code 0
`

whether returning the task/coroutine directly was intended or not, I think it's better to keep it as before, for consistency with other functions