### PR TITLE
Fix passing start_ts > end_ts when fetching historical klines

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -835,6 +835,10 @@ class Client(object):
                 start_ts = increment_month(start_ts)
             else:
                 start_ts += timeframe
+                
+            # check if end_ts is reached
+            if end_ts is not None and start_ts >= end_ts:
+                break
 
             # sleep after every 3rd call to be kind to the API
             if idx % 3 == 0:
@@ -919,6 +923,10 @@ class Client(object):
                 start_ts = increment_month(start_ts)
             else:
                 start_ts += timeframe
+                
+            # check if end_ts is reached
+            if end_ts is not None and start_ts >= end_ts:
+                break
 
             # sleep after every 3rd call to be kind to the API
             if idx % 3 == 0:


### PR DESCRIPTION
When end_ts is passed historical klines are fetched until Binance API returns no results. With every query start_ts is incremented. For the most part this cause one unnecessary query to Binance to be made, where start_ts is bigger than end_ts. Moreover, when fetching klines for future markets (not spot), Binance API returns an error in such condition (-1023). This makes it impossible to fetch klines for future markets when providing end_str param.