### PR TITLE
Fixed threaded stream and futures user socket

### DIFF
--- a/binance/streams.py
+++ b/binance/streams.py
@@ -1064,7 +1064,11 @@ class BinanceSocketManager:
         Message Format - see Binanace API docs for all types
         """
 
-        return self._get_account_socket('futures', stream_url=self.FSTREAM_URL)
+        stream_url = self.FSTREAM_URL
+        if self.testnet:
+            stream_url = self.FSTREAM_TESTNET_URL
+
+        return self._get_account_socket('futures', stream_url=stream_url)
 
     def margin_socket(self):
         """Start a websocket for cross-margin data

--- a/binance/threaded_stream.py
+++ b/binance/threaded_stream.py
@@ -16,7 +16,7 @@ class ThreadedApiManager(threading.Thread):
 
         """
         super().__init__()
-        self._loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
+        self._loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
         self._client: Optional[AsyncClient] = None
         self._running: bool = True
         self._socket_running: Dict[str, bool] = {}


### PR DESCRIPTION
Fix #1200 and #1174 with Python 3.8.13

The stream does not work anymore with the standard code presented. We have to change the threading approach to run it successfully. Additionally, we should also be able to use the testnet for the futures stream in combination with the threaded approach, so that has also been fixed. @sammchardy 

Minimal testing example:

```python
import time
from binance.streams import ThreadedWebsocketManager

def handler(order_data):
    print(order_data)

manager = ThreadedWebsocketManager(
    API_KEY, 
    API_SECRET, 
    testnet=True
)

manager.daemon = True # ctrl-c works
manager.start()
manager.start_futures_user_socket(handler)

while True:
    # run your other code here
    time.sleep(0.1)
```