### PR TITLE
generalize ThreadedApiManager nomenclature beyond sockets.

### DIFF
--- a/binance/depthcache.py
+++ b/binance/depthcache.py
@@ -4,6 +4,7 @@ import asyncio
 import time
 from typing import Optional, Dict, Callable
 
+from .listeners import AbstractListener
 from .streams import BinanceSocketManager
 from .threaded_stream import ThreadedApiManager
 
@@ -128,7 +129,7 @@ class DepthCache(object):
         return lst
 
 
-class BaseDepthCacheManager:
+class BaseDepthCacheManager(AbstractListener):
     DEFAULT_REFRESH = 60 * 30  # 30 minutes
     TIMEOUT = 60
 
@@ -445,7 +446,7 @@ class ThreadedDepthCacheManager(ThreadedApiManager):
             **kwargs
         )
         path = symbol.lower() + '@depth' + str(limit)
-        self._socket_running[path] = True
+        self._listener_running[path] = True
         self._loop.call_soon(asyncio.create_task, self.start_listener(dcm, path, callback))
         return path
 

--- a/binance/listeners.py
+++ b/binance/listeners.py
@@ -1,0 +1,9 @@
+from contextlib import AbstractAsyncContextManager
+from abc import abstractmethod
+
+
+class AbstractListener(AbstractAsyncContextManager):
+
+    @abstractmethod
+    async def recv(self):
+        ...


### PR DESCRIPTION
This PR generalizes the nomenclature in `ThreadedApiManager` from referring to every type of listener as a socket to a a generic listener object of type `AbstractListener`. `AbstractListener` subclasses `AbstractAsyncContextManager`  with a definition for `async def recv(self)` and has children `BaseDepthCacheManager` and `ReconnectingWebsocket`. 

I couldn't find where to put the interface so I put it in its own file `listeners.py`.