### PR TITLE
fix futures book limit

### DIFF
--- a/binance/depthcache.py
+++ b/binance/depthcache.py
@@ -407,7 +407,7 @@ class FuturesDepthCacheManager(BaseDepthCacheManager):
         self._depth_cache.update_time = msg.get('E') or msg.get('lastUpdateId')
 
     def _get_socket(self):
-        sock = self._bm.futures_depth_socket(self._symbol)
+        sock = self._bm.futures_depth_socket(self._symbol, depth=self._limit)
         return sock
 
 


### PR DESCRIPTION
This is resolving https://github.com/sammchardy/python-binance/issues/1257

Allowing to pass depth parameter to BinanceSocketManager.futures_depth_socket, to allow limiting amount of levels when starting to future depth socket.