### PR TITLE
feat(orjson): Add support for orjson

### DIFF
--- a/binance/exceptions.py
+++ b/binance/exceptions.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-import json
+import orjson as json
 
 
 class BinanceAPIException(Exception):

--- a/binance/streams.py
+++ b/binance/streams.py
@@ -1,6 +1,6 @@
 import asyncio
 import gzip
-import json
+import orjson as json
 import logging
 import time
 from asyncio import sleep

--- a/examples/save_historical_data.py
+++ b/examples/save_historical_data.py
@@ -1,7 +1,7 @@
 import time
 import dateparser
 import pytz
-import json
+import orjson as json
 
 from datetime import datetime
 from binance.client import Client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp
 dateparser
 requests
-ujson
+orjson
 websockets


### PR DESCRIPTION
At some point `ujson` was used for json loads https://github.com/sammchardy/python-binance/pull/383 but it does not seem to be the case any more. This code has be lost. I do in `v1.0.16`
```
[hannotauber@toolbox python-binance]$ grep -r ujson
docs/changelog.rst:- Stock json lib to ujson (https://github.com/sammchardy/python-binance/pull/383)
requirements.txt:ujson
setup.py:        'requests', 'six', 'dateparser', 'aiohttp', 'ujson', 'websockets'
```

I am more confident with the work and benchmark results of `orjson` along with the licensing which comes with Apache 2 and MIT licenses.