### PR TITLE
creating new event loop if there is no current event loop in Threaded…

### DIFF
--- a/binance/threaded_stream.py
+++ b/binance/threaded_stream.py
@@ -5,6 +5,7 @@ from typing import Optional, Dict
 from .client import AsyncClient
 
 
+        
 class ThreadedApiManager(threading.Thread):
 
     def __init__(
@@ -16,7 +17,7 @@ class ThreadedApiManager(threading.Thread):
 
         """
         super().__init__()
-        self._loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
+        self._loop: asyncio.AbstractEventLoop = get_loop()
         self._client: Optional[AsyncClient] = None
         self._running: bool = True
         self._socket_running: Dict[str, bool] = {}
@@ -71,3 +72,19 @@ class ThreadedApiManager(threading.Thread):
         self._loop.call_soon(asyncio.create_task, self.stop_client())
         for socket_name in self._socket_running.keys():
             self._socket_running[socket_name] = False
+
+
+def get_loop():
+    ''' check if there is an event loop in the current thread, if not create one
+    inspired by https://stackoverflow.com/questions/46727787/runtimeerror-there-is-no-current-event-loop-in-thread-in-async-apscheduler
+    '''
+    try:
+        loop = asyncio.get_event_loop()
+        return loop
+    except RuntimeError as e:
+        if str(e).startswith('There is no current event loop in thread'):
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            return loop
+        else:
+            raise


### PR DESCRIPTION
I tried to run the `ThreadedWebsocketManager` while using Flask, and I received the following error:
```
 File "/usr/lib/python3.10/asyncio/events.py", line 656, in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.'
RuntimeError: There is no current event loop in thread 'Thread-1 (main)'.
```

Digging deeper, I saw this error happening when I ran the `ThreadedWebsocketManager` in a separate thread. 

Example code:
```python
def main():


    twm = ThreadedWebsocketManager(
        api_key=mother_future_api_key, api_secret=mother_future_api_secret, testnet=True
    )
    twm.start()
    twm.start_coin_futures_socket(callback=handle_socket_message)

    twm.join()


def handle_socket_message(msg):
    print(f"message type: {msg['e']}")
    print(msg)


if __name__ == "__main__":
    threading.Thread(target=main).start()


```

