### PR TITLE
Update endpoint for get_products

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -434,7 +434,7 @@ class Client(BaseClient):
         :raises: BinanceRequestException, BinanceAPIException
 
         """
-        products = self._request_website('get', 'exchange-api/v1/public/asset-service/product/get-products')
+        products = self._request_website('get', 'bapi/asset/v2/public/asset-service/product/get-products?includeEtf=true')
         return products
 
     def get_exchange_info(self) -> Dict:


### PR DESCRIPTION
endpoint changed for `get_products` from `exchange-api/v1/public/asset-service/product/get-products` (obsolete) to  `bapi/asset/v2/public/asset-service/product/get-products?includeEtf=true` (new)