### PR TITLE
fix bad argument to exit_core in ReconnectingWebsocket

### DIFF
--- a/binance/streams.py
+++ b/binance/streams.py
@@ -339,7 +339,7 @@ class BinanceSocketManager:
     def _get_socket(
         self, path: str, stream_url: Optional[str] = None, prefix: str = 'ws/', is_binary: bool = False,
         socket_type: BinanceSocketType = BinanceSocketType.SPOT
-    ) -> str:
+    ) -> ReconnectingWebsocket:
         conn_id = f'{socket_type}_{path}'
         if conn_id not in self._conns:
             self._conns[conn_id] = ReconnectingWebsocket(

--- a/binance/streams.py
+++ b/binance/streams.py
@@ -346,7 +346,7 @@ class BinanceSocketManager:
                 path=path,
                 url=self._get_stream_url(stream_url),
                 prefix=prefix,
-                exit_coro=self._exit_socket,
+                exit_coro=lambda p: self._exit_socket(f'{socket_type}_{p}'),
                 is_binary=is_binary
             )
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
 coverage
 flake8
 pytest
+pytest-asyncio
 pytest-cov
 pytest-flake8
 python-coveralls

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -1,0 +1,15 @@
+from binance.streams import BinanceSocketManager
+from binance.client import AsyncClient
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_socket_stopped_on_aexit():
+    client = AsyncClient()
+    bm = BinanceSocketManager(client)
+    ts1 = bm.trade_socket('BNBBTC')
+    async with ts1:
+        pass
+    ts2 = bm.trade_socket('BNBBTC')
+    assert ts2 is not ts1, "socket should be removed from _conn on exit"
+    await client.close_connection()


### PR DESCRIPTION
`_exit_coro` is passed the wrong argument in `__aexit__`, so the object is not being removed from the `_conn` dictionary in the `BinanceSocketManager`.