### PR TITLE
Fix method name typo in Client.futures_comission_rate

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -6398,7 +6398,7 @@ class Client(BaseClient):
         """
         return self._request_futures_api('get', 'apiTradingStatus', signed=True, data=params)
 
-    def futures_comission_rate(self, **params):
+    def futures_commission_rate(self, **params):
         """Get Futures commission rate
 
         https://binance-docs.github.io/apidocs/futures/en/#user-commission-rate-user_data
@@ -8897,7 +8897,7 @@ class AsyncClient(BaseClient):
     async def futures_api_trading_status(self, **params):
         return await self._request_futures_api('get', 'apiTradingStatus', signed=True, data=params)
 
-    async def futures_comission_rate(self, **params):
+    async def futures_commission_rate(self, **params):
         return await self._request_futures_api('get', 'commissionRate', signed=True, data=params)
 
     async def futures_adl_quantile_estimate(self, **params):


### PR DESCRIPTION
The phrase comission in Client.futures_comission_rate seems like a typo. Changing it to "commission" makes more sense.