### PR TITLE
Dont force name param in withdraw

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -2745,9 +2745,6 @@ class Client(BaseClient):
         :raises: BinanceRequestException, BinanceAPIException
 
         """
-        # force a name for the withdrawal if one not set
-        if 'coin' in params and 'name' not in params:
-            params['name'] = params['coin']
         return self._request_margin_api('post', 'capital/withdraw/apply', True, data=params)
 
     def get_deposit_history(self, **params):


### PR DESCRIPTION
The `name` parameter is no longer mandatory according to Binance docs (https://developers.binance.com/docs/binance-trading-api/spot#withdrawuser_data) and my test.

It may only do harm if it automatically saves the withdrawal address to the address book and bloats it (the limit is 500 items and then it starts rejecting withdrawals).