### PR TITLE
use correct account status path if the tld is .us, add param for vers…

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -2251,11 +2251,12 @@ class Client(BaseClient):
         """
         return self._request_margin_api('get', 'system/status')
 
-    def get_account_status(self, **params):
+    def get_account_status(self, version=1,**params):
         """Get account status detail.
 
         https://binance-docs.github.io/apidocs/spot/en/#account-status-sapi-user_data
-
+        :param version: the api version
+        :param version: int
         :param recvWindow: the number of milliseconds the request is valid for
         :type recvWindow: int
 
@@ -2268,7 +2269,11 @@ class Client(BaseClient):
             }
 
         """
-        return self._request_margin_api('get', 'account/status', True, data=params)
+        if self.tld == 'us':
+            path = 'accountStatus'
+        else:
+            path = 'account/status'
+        return self._request_margin_api('get', path, True, version, data=params)
 
     def get_account_api_trading_status(self, **params):
         """Fetch account api trading status detail.


### PR DESCRIPTION
…ion in Client.get_account_status

The paths for the .com and .us account status endpoints have diverged. We now check the tld configured in the Client and use path 'accountStatus' if the tld is .us. We also allow the caller to pass an api version, which defaults to 1 if not passed. This leaves the functionality the same for traders lucky enough to interact with the .com api.