### PR TITLE
Added CountdownCancelAll to Auto-Cancel All Open Orders

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -6869,6 +6869,14 @@ class Client(BaseClient):
         """
         return self._request_futures_api('delete', 'batchOrders', True, data=params)
 
+    def futures_countdown_cancel_all(self, **params):
+        """Cancel all open orders of the specified symbol at the end of the specified countdown.
+
+        https://binance-docs.github.io/apidocs/futures/en/#auto-cancel-all-open-orders-trade
+
+        """
+        return self._request_futures_api('post', 'countdownCancelAll', True, data=params)
+    
     def futures_account_balance(self, **params):
         """Get futures account balance
 

--- a/binance/client.py
+++ b/binance/client.py
@@ -6880,8 +6880,6 @@ class Client(BaseClient):
         :type countdownTime: int
         :param recvWindow: optional - the number of milliseconds the request is valid for
         :type recvWindow: int
-        :param timestamp: required
-        :type timestamp: int
 	
         :returns: API response
 

--- a/binance/client.py
+++ b/binance/client.py
@@ -9294,6 +9294,9 @@ class AsyncClient(BaseClient):
     async def futures_cancel_orders(self, **params):
         return await self._request_futures_api('delete', 'batchOrders', True, data=params)
 
+    async def futures_countdown_cancel_all(self, **params):
+        return await self._request_futures_api('post', 'countdownCancelAll', True, data=params)
+    
     async def futures_account_balance(self, **params):
         return await self._request_futures_api('get', 'balance', True, version=2, data=params)
 

--- a/binance/client.py
+++ b/binance/client.py
@@ -6873,6 +6873,23 @@ class Client(BaseClient):
         """Cancel all open orders of the specified symbol at the end of the specified countdown.
 
         https://binance-docs.github.io/apidocs/futures/en/#auto-cancel-all-open-orders-trade
+	
+        :param symbol: required
+        :type symbol: str
+        :param countdownTime: required
+        :type countdownTime: int
+        :param recvWindow: optional - the number of milliseconds the request is valid for
+        :type recvWindow: int
+        :param timestamp: required
+        :type timestamp: int
+	
+        :returns: API response
+
+        .. code-block:: python
+        {
+            "symbol": "BTCUSDT", 
+            "countdownTime": "100000"
+        }
 
         """
         return self._request_futures_api('post', 'countdownCancelAll', True, data=params)


### PR DESCRIPTION
Added CountdownCancelAll to [Auto-Cancel All Open Orders](https://binance-docs.github.io/apidocs/futures/en/#auto-cancel-all-open-orders-trade)
