### PR TITLE
Added delist schedules for spot and margin market data

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -4596,6 +4596,40 @@ class Client(BaseClient):
         """
         return self._request_margin_api('get', 'margin/maxTransferable', signed=True, data=params)
 
+    def get_margin_delist_schedule(self, **params):
+        """Get tokens or symbols delist schedule for cross margin and isolated margin
+
+        https://binance-docs.github.io/apidocs/spot/en/#get-tokens-or-symbols-delist-schedule-for-cross-margin-and-isolated-margin-market_data
+
+        :param recvWindow: optional - the number of milliseconds the request is valid for
+        :type recvWindow: int
+
+        :returns: API response
+
+        .. code-block:: python
+            [
+                {
+                    "delistTime": 1686161202000,
+                    "crossMarginAssets": [
+                        "BTC",
+                        "USDT"
+                    ],
+                    "isolatedMarginSymbols": [
+                        "ADAUSDT",
+                        "BNBUSDT"
+                    ]
+                },
+                {
+                    "delistTime": 1686222232000,
+                    "crossMarginAssets": [
+                        "ADA"
+                    ],
+                    "isolatedMarginSymbols": []
+                }
+            ]
+        """
+        return self._request_margin_api('get', '/margin/delist-schedule', signed=True, data=params)
+
     # Margin OCO
 
     def create_margin_oco_order(self, **params):
@@ -8778,7 +8812,7 @@ class AsyncClient(BaseClient):
     get_asset_details.__doc__ = Client.get_asset_details.__doc__
 
     async def get_spot_delist_schedule(self, **params):
-        return self._request_margin_api('get', '/spot/delist-schedule', True, data=params)
+        return self._request_margin_api('get', '/spot/delist-schedule', signed=True, data=params)
 
     # Withdraw Endpoints
 
@@ -8979,6 +9013,9 @@ class AsyncClient(BaseClient):
 
     async def get_max_margin_transfer(self, **params):
         return await self._request_margin_api('get', 'margin/maxTransferable', signed=True, data=params)
+
+    async def get_margin_delist_schedule(self, **params):
+        return self._request_margin_api('get', '/margin/delist-schedule', signed=True, data=params)
 
     # Margin OCO
 

--- a/binance/client.py
+++ b/binance/client.py
@@ -6869,6 +6869,14 @@ class Client(BaseClient):
         """
         return self._request_futures_api('delete', 'batchOrders', True, data=params)
 
+    def futures_countdown_cancel_all(self, **params):
+        """Cancel all open orders of the specified symbol at the end of the specified countdown.
+
+        https://binance-docs.github.io/apidocs/futures/en/#auto-cancel-all-open-orders-trade
+
+        """
+        return self._request_futures_api('post', 'countdownCancelAll', True, data=params)
+    
     def futures_account_balance(self, **params):
         """Get futures account balance
 

--- a/binance/client.py
+++ b/binance/client.py
@@ -6880,8 +6880,6 @@ class Client(BaseClient):
         :type countdownTime: int
         :param recvWindow: optional - the number of milliseconds the request is valid for
         :type recvWindow: int
-        :param timestamp: required
-        :type timestamp: int
 	
         :returns: API response
 

--- a/binance/client.py
+++ b/binance/client.py
@@ -9294,6 +9294,9 @@ class AsyncClient(BaseClient):
     async def futures_cancel_orders(self, **params):
         return await self._request_futures_api('delete', 'batchOrders', True, data=params)
 
+    async def futures_countdown_cancel_all(self, **params):
+        return await self._request_futures_api('post', 'countdownCancelAll', True, data=params)
+    
     async def futures_account_balance(self, **params):
         return await self._request_futures_api('get', 'balance', True, version=2, data=params)
 

--- a/binance/client.py
+++ b/binance/client.py
@@ -2704,6 +2704,35 @@ class Client(BaseClient):
         """
         return self._request_margin_api('get', 'asset/assetDetail', True, data=params)
 
+    def get_spot_delist_schedule(self, **params):
+        """Get symbols delist schedule for spot
+	
+	https://binance-docs.github.io/apidocs/spot/en/#get-symbols-delist-schedule-for-spot-market_data
+
+        :param recvWindow: optional - the number of milliseconds the request is valid for
+        :type recvWindow: int
+
+        :returns: API response
+
+        .. code-block:: python
+            [
+                {
+                    "delistTime": 1686161202000,
+                    "symbols": [
+                        "ADAUSDT",
+                        "BNBUSDT"
+                    ]
+                },
+                {
+                    "delistTime": 1686222232000,
+                    "symbols": [
+                        "ETHUSDT"
+                    ]
+                }
+            ]
+        """
+        return self._request_margin_api('get', '/spot/delist-schedule', True, data=params)
+
     # Withdraw Endpoints
 
     def withdraw(self, **params):
@@ -8747,6 +8776,9 @@ class AsyncClient(BaseClient):
     async def get_asset_details(self, **params):
         return await self._request_margin_api('get', 'asset/assetDetail', True, data=params)
     get_asset_details.__doc__ = Client.get_asset_details.__doc__
+
+    async def get_spot_delist_schedule(self, **params):
+        return self._request_margin_api('get', '/spot/delist-schedule', True, data=params)
 
     # Withdraw Endpoints
 

--- a/binance/client.py
+++ b/binance/client.py
@@ -8812,7 +8812,7 @@ class AsyncClient(BaseClient):
     get_asset_details.__doc__ = Client.get_asset_details.__doc__
 
     async def get_spot_delist_schedule(self, **params):
-        return self._request_margin_api('get', '/spot/delist-schedule', signed=True, data=params)
+        return await self._request_margin_api('get', '/spot/delist-schedule', signed=True, data=params)
 
     # Withdraw Endpoints
 
@@ -9015,7 +9015,7 @@ class AsyncClient(BaseClient):
         return await self._request_margin_api('get', 'margin/maxTransferable', signed=True, data=params)
 
     async def get_margin_delist_schedule(self, **params):
-        return self._request_margin_api('get', '/margin/delist-schedule', signed=True, data=params)
+        return await self._request_margin_api('get', '/margin/delist-schedule', signed=True, data=params)
 
     # Margin OCO
 

--- a/binance/client.py
+++ b/binance/client.py
@@ -6873,6 +6873,23 @@ class Client(BaseClient):
         """Cancel all open orders of the specified symbol at the end of the specified countdown.
 
         https://binance-docs.github.io/apidocs/futures/en/#auto-cancel-all-open-orders-trade
+	
+        :param symbol: required
+        :type symbol: str
+        :param countdownTime: required
+        :type countdownTime: int
+        :param recvWindow: optional - the number of milliseconds the request is valid for
+        :type recvWindow: int
+        :param timestamp: required
+        :type timestamp: int
+	
+        :returns: API response
+
+        .. code-block:: python
+        {
+            "symbol": "BTCUSDT", 
+            "countdownTime": "100000"
+        }
 
         """
         return self._request_futures_api('post', 'countdownCancelAll', True, data=params)


### PR DESCRIPTION
Added get_spot_delist_schedule for [Get symbols delist schedule for spot](https://binance-docs.github.io/apidocs/spot/en/#get-symbols-delist-schedule-for-spot-market_data).
Added get_margin_delist_schedule for [Get tokens or symbols delist schedule for cross margin and isolated margin](https://binance-docs.github.io/apidocs/spot/en/#get-tokens-or-symbols-delist-schedule-for-cross-margin-and-isolated-margin-market_data).