### PR TITLE
Fixed event loop creation issue in threaded_stream.py file

### DIFF
--- a/binance/threaded_stream.py
+++ b/binance/threaded_stream.py
@@ -17,7 +17,7 @@ class ThreadedApiManager(threading.Thread):
 
         """
         super().__init__()
-        self._loop: asyncio.AbstractEventLoop = get_loop()
+        self._loop: asyncio.AbstractEventLoop = asyncio.get_event_loop() if asyncio.get_event_loop().is_running() else asyncio.new_event_loop()
         self._client: Optional[AsyncClient] = None
         self._running: bool = True
         self._socket_running: Dict[str, bool] = {}


### PR DESCRIPTION
Fixed event loop creation issue in threaded_stream.py file by simple checking if the loop is already created or not. If is not created - create a new one, otherwise get current one