### PR TITLE
Add - futures_modify_order function

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -6806,6 +6806,14 @@ class Client(BaseClient):
 
         """
         return self._request_futures_api('post', 'order', True, data=params)
+    
+    def futures_modify_order(self, **params):
+        """Modify an existing order. Currently only LIMIT order modification is supported.
+
+        https://binance-docs.github.io/apidocs/futures/en/#modify-order-trade
+
+        """
+        return self._request_futures_api('put', 'order', True, data=params)
 
     def futures_place_batch_order(self, **params):
         """Send in new orders.


### PR DESCRIPTION
Simple but missing function, to be able to modify an existing order.
For example it is usefull for modifing the quantity, or the price of an open order.

Using the same url (order) as for creating a new order but with a PUT method instead of a POST method.