### PR TITLE
fixing syntax error

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -9263,7 +9263,7 @@ class AsyncClient(BaseClient):
     query_universal_transfer_history.__doc__ = Client.query_universal_transfer_history.__doc__
 
     async def get_trade_fee(self, **params):
-        if self.tld == 'us'
+        if self.tld == "us":
             endpoint = 'asset/query/trading-fee'
         else:
             endpoint = 'asset/tradeFee'
@@ -9392,7 +9392,7 @@ class AsyncClient(BaseClient):
     async def get_margin_delist_schedule(self, **params):
         return await self._request_margin_api('get', 'margin/delist-schedule', True, data=params)
     get_margin_delist_schedule.__doc__ = Client.get_margin_delist_schedule.__doc__
-    
+
     async def get_margin_asset(self, **params):
         return await self._request_margin_api('get', 'margin/asset', data=params)
     get_margin_asset.__doc__ = Client.get_margin_asset.__doc__
@@ -9894,7 +9894,7 @@ class AsyncClient(BaseClient):
 
     async def futures_countdown_cancel_all(self, **params):
         return await self._request_futures_api('post', 'countdownCancelAll', True, data=params)
-    
+
     async def futures_account_balance(self, **params):
         return await self._request_futures_api('get', 'balance', True, version=2, data=params)
 

--- a/binance/client.py
+++ b/binance/client.py
@@ -2696,7 +2696,7 @@ class Client(BaseClient):
             ]
 
         """
-        if self.tld == 'us'
+        if self.tld == 'us':
             endpoint = 'asset/query/trading-fee'
         else:
             endpoint = 'asset/tradeFee'


### PR DESCRIPTION
When running the async clients I am getting this error:
gridbot_celery  |     from binance import Client
gridbot_celery  |   File "/usr/local/lib/python3.10/site-packages/binance/__init__.py", line 9, in <module>
gridbot_celery  |     from binance.client import Client, AsyncClient  # noqa
gridbot_celery  |   File "/usr/local/lib/python3.10/site-packages/binance/client.py", line 2699
gridbot_celery  |     if self.tld == 'us'
gridbot_celery  |                        ^
gridbot_celery  | SyntaxError: expected ':'
 
I've added the colon in the relevant line