### PR TITLE
fix: adjust logs in reconnecting websocket

### DIFF
--- a/binance/ws/reconnecting_websocket.py
+++ b/binance/ws/reconnecting_websocket.py
@@ -211,7 +211,7 @@ class ReconnectingWebsocket:
                                     f"Message queue size {self._queue.qsize()} exceeded maximum {self.MAX_QUEUE_SIZE}"
                                 )
                 except asyncio.TimeoutError:
-                    self._log.error(f"no message in {self.TIMEOUT} seconds")
+                    self._log.debug(f"no message in {self.TIMEOUT} seconds")
                     # _no_message_received_reconnect
                 except asyncio.CancelledError as e:
                     self._log.error(f"cancelled error {e}")


### PR DESCRIPTION
- Remove CANCEL read_loop error log. This is not an error as the loop is closed before intentionally.
- Change log debug errors of errors to errors
- Fix error type for when message queue is full