### PR TITLE
feat(client): add futures_mark_price_klines, futures_index_price_klines, futures_premium_index_klines

### DIFF
--- a/binance/async_client.py
+++ b/binance/async_client.py
@@ -1676,25 +1676,19 @@ class AsyncClient(BaseClient):
         return await self._request_futures_api("get", "klines", data=params)
 
     async def futures_mark_price_klines(self, **params):
-            return await self._request_futures_api("get", "markPriceKlines", data=params)
+        return await self._request_futures_api("get", "markPriceKlines", data=params)
 
-    futures_mark_price_klines.__doc__ = (
-            Client.futures_mark_price_klines.__doc__
-        )
+    futures_mark_price_klines.__doc__ = Client.futures_mark_price_klines.__doc__
 
     async def futures_index_price_klines(self, **params):
-            return await self._request_futures_api("get", "indexPriceKlines", data=params)
+        return await self._request_futures_api("get", "indexPriceKlines", data=params)
 
-    futures_index_price_klines.__doc__ = (
-            Client.futures_index_price_klines.__doc__
-        )
+    futures_index_price_klines.__doc__ = Client.futures_index_price_klines.__doc__
 
     async def futures_premium_index_klines(self, **params):
-            return await self._request_futures_api("get", "premiumIndexKlines", data=params)
+        return await self._request_futures_api("get", "premiumIndexKlines", data=params)
 
-    futures_premium_index_klines.__doc__ = (
-            Client.futures_index_price_klines.__doc__
-        )
+    futures_premium_index_klines.__doc__ = Client.futures_index_price_klines.__doc__
 
     async def futures_continous_klines(self, **params):
         return await self._request_futures_api("get", "continuousKlines", data=params)
@@ -2020,13 +2014,17 @@ class AsyncClient(BaseClient):
         return await self._request_futures_coin_api(
             "get", "markPriceKlines", data=params
         )
+
     futures_coin_mark_price_klines.__doc__ = Client.futures_mark_price_klines.__doc__
 
     async def futures_coin_premium_index_klines(self, **params):
         return await self._request_futures_coin_api(
             "get", "premiumIndexKlines", data=params
         )
-    futures_coin_premium_index_klines.__doc__ = (Client.futures_premium_index_klines.__doc__)
+
+    futures_coin_premium_index_klines.__doc__ = (
+        Client.futures_premium_index_klines.__doc__
+    )
 
     async def futures_coin_mark_price(self, **params):
         return await self._request_futures_coin_api("get", "premiumIndex", data=params)
@@ -3839,4 +3837,6 @@ class AsyncClient(BaseClient):
             "get", "block/user-trades", signed=True, data=params
         )
 
-    options_account_get_block_trades.__doc__ = Client.options_account_get_block_trades.__doc__
+    options_account_get_block_trades.__doc__ = (
+        Client.options_account_get_block_trades.__doc__
+    )

--- a/binance/async_client.py
+++ b/binance/async_client.py
@@ -1667,6 +1667,20 @@ class AsyncClient(BaseClient):
     async def futures_klines(self, **params):
         return await self._request_futures_api("get", "klines", data=params)
 
+    async def futures_mark_price_klines(self, **params):
+            return await self._request_futures_api("get", "markPriceKlines", data=params)
+
+    futures_mark_price_klines.__doc__ = (
+            Client.futures_mark_price_klines.__doc__
+        )
+
+    async def futures_index_price_klines(self, **params):
+            return await self._request_futures_api("get", "indexPriceKlines", data=params)
+
+    futures_index_price_klines.__doc__ = (
+            Client.futures_index_price_klines.__doc__
+        )
+
     async def futures_continous_klines(self, **params):
         return await self._request_futures_api("get", "continuousKlines", data=params)
 

--- a/binance/async_client.py
+++ b/binance/async_client.py
@@ -1685,6 +1685,13 @@ class AsyncClient(BaseClient):
             Client.futures_index_price_klines.__doc__
         )
 
+    async def futures_premium_index_klines(self, **params):
+            return await self._request_futures_api("get", "premiumIndexKlines", data=params)
+
+    futures_premium_index_klines.__doc__ = (
+            Client.futures_index_price_klines.__doc__
+        )
+
     async def futures_continous_klines(self, **params):
         return await self._request_futures_api("get", "continuousKlines", data=params)
 

--- a/binance/async_client.py
+++ b/binance/async_client.py
@@ -406,6 +406,10 @@ class AsyncClient(BaseClient):
             return await self.futures_mark_price_klines(**params)
         elif HistoricalKlinesType.FUTURES_INDEX_PRICE == klines_type:
             return await self.futures_index_price_klines(**params)
+        elif HistoricalKlinesType.FUTURES_COIN_MARK_PRICE == klines_type:
+            return await self.futures_coin_mark_price_klines(**params)
+        elif HistoricalKlinesType.FUTURES_COIN_INDEX_PRICE == klines_type:
+            return await self.futures_coin_index_price_klines(**params)
         else:
             raise NotImplementedException(klines_type)
 
@@ -2016,6 +2020,13 @@ class AsyncClient(BaseClient):
         return await self._request_futures_coin_api(
             "get", "markPriceKlines", data=params
         )
+    futures_coin_mark_price_klines.__doc__ = Client.futures_mark_price_klines.__doc__
+
+    async def futures_coin_premium_index_klines(self, **params):
+        return await self._request_futures_coin_api(
+            "get", "premiumIndexKlines", data=params
+        )
+    futures_coin_premium_index_klines.__doc__ = (Client.futures_premium_index_klines.__doc__)
 
     async def futures_coin_mark_price(self, **params):
         return await self._request_futures_coin_api("get", "premiumIndex", data=params)

--- a/binance/async_client.py
+++ b/binance/async_client.py
@@ -402,6 +402,10 @@ class AsyncClient(BaseClient):
             return await self.futures_klines(**params)
         elif HistoricalKlinesType.FUTURES_COIN == klines_type:
             return await self.futures_coin_klines(**params)
+        elif HistoricalKlinesType.FUTURES_MARK_PRICE == klines_type:
+            return await self.futures_mark_price_klines(**params)
+        elif HistoricalKlinesType.FUTURES_INDEX_PRICE == klines_type:
+            return await self.futures_index_price_klines(**params)
         else:
             raise NotImplementedException(klines_type)
 

--- a/binance/client.py
+++ b/binance/client.py
@@ -7102,6 +7102,14 @@ class Client(BaseClient):
         """
         return self._request_futures_api("get", "markPriceKlines", data=params)
 
+    def futures_index_price_klines(self, **params):
+        """Kline/candlestick bars for the index price of a symbol. Klines are uniquely identified by their open time.
+
+        https://binance-docs.github.io/apidocs/futures/en/#index-price-kline-candlestick-data
+
+        """
+        return self._request_futures_api("get", "indexPriceKlines", data=params)
+
     def futures_continous_klines(self, **params):
         """Kline/candlestick bars for a specific contract type. Klines are uniquely identified by their open time.
 

--- a/binance/client.py
+++ b/binance/client.py
@@ -698,6 +698,8 @@ class Client(BaseClient):
             return self.futures_klines(**params)
         elif HistoricalKlinesType.FUTURES_COIN == klines_type:
             return self.futures_coin_klines(**params)
+        elif HistoricalKlinesType.FUTURES_MARK_PRICE == klines_type:
+            return self.futures_mark_price_klines(**params)
         else:
             raise NotImplementedException(klines_type)
 
@@ -7092,6 +7094,14 @@ class Client(BaseClient):
         """
         return self._request_futures_api("get", "klines", data=params)
 
+    def futures_mark_price_klines(self, **params):
+        """Kline/candlestick bars for the mark price of a symbol. Klines are uniquely identified by their open time.
+
+        https://binance-docs.github.io/apidocs/futures/en/#mark-price-kline-candlestick-data
+
+        """
+        return self._request_futures_api("get", "markPriceKlines", data=params)
+
     def futures_continous_klines(self, **params):
         """Kline/candlestick bars for a specific contract type. Klines are uniquely identified by their open time.
 
@@ -7126,6 +7136,34 @@ class Client(BaseClient):
             end_str=end_str,
             limit=limit,
             klines_type=HistoricalKlinesType.FUTURES,
+        )
+
+    def futures_historical_mark_price_klines(
+        self, symbol, interval, start_str, end_str=None, limit=500
+    ):
+        """Get historical futures mark price klines from Binance
+
+        :param symbol: Name of symbol pair e.g. BNBBTC
+        :type symbol: str
+        :param interval: Binance Kline interval
+        :type interval: str
+        :param start_str: Start date string in UTC format or timestamp in milliseconds
+        :type start_str: str|int
+        :param end_str: optional - end date string in UTC format or timestamp in milliseconds (default will fetch everything up to now)
+        :type end_str: str|int
+        :param limit: Default 500; max 1000.
+        :type limit: int
+
+        :return: list of OHLCV values (Open time, Open, High, Low, Close, Volume, Close time, Quote asset volume, Number of trades, Taker buy base asset volume, Taker buy quote asset volume, Ignore)
+
+        """
+        return self._historical_klines(
+            symbol,
+            interval,
+            start_str,
+            end_str=end_str,
+            limit=limit,
+            klines_type=HistoricalKlinesType.FUTURES_MARK_PRICE,
         )
 
     def futures_historical_klines_generator(

--- a/binance/client.py
+++ b/binance/client.py
@@ -700,6 +700,8 @@ class Client(BaseClient):
             return self.futures_coin_klines(**params)
         elif HistoricalKlinesType.FUTURES_MARK_PRICE == klines_type:
             return self.futures_mark_price_klines(**params)
+        elif HistoricalKlinesType.FUTURES_INDEX_PRICE == klines_type:
+            return self.futures_index_price_klines(**params)
         else:
             raise NotImplementedException(klines_type)
 

--- a/binance/client.py
+++ b/binance/client.py
@@ -702,6 +702,10 @@ class Client(BaseClient):
             return self.futures_mark_price_klines(**params)
         elif HistoricalKlinesType.FUTURES_INDEX_PRICE == klines_type:
             return self.futures_index_price_klines(**params)
+        elif HistoricalKlinesType.FUTURES_COIN_MARK_PRICE == klines_type:
+            return self.futures_coin_mark_price_klines(**params)
+        elif HistoricalKlinesType.FUTURES_COIN_INDEX_PRICE == klines_type:
+            return self.futures_coin_index_price_klines(**params)
         else:
             raise NotImplementedException(klines_type)
 
@@ -7824,6 +7828,16 @@ class Client(BaseClient):
 
         """
         return self._request_futures_coin_api("get", "indexPriceKlines", data=params)
+
+
+    def futures_coin_premium_index_klines(self, **params):
+        """Kline/candlestick bars for the index price of a pair..
+
+        https://binance-docs.github.io/apidocs/delivery/en/#premium-index-kline-data
+
+        """
+        return self._request_futures_coin_api("get", "premiumIndexKlines", data=params)
+
 
     def futures_coin_mark_price_klines(self, **params):
         """Kline/candlestick bars for the index price of a pair..

--- a/binance/client.py
+++ b/binance/client.py
@@ -7112,6 +7112,14 @@ class Client(BaseClient):
         """
         return self._request_futures_api("get", "indexPriceKlines", data=params)
 
+    def futures_premium_index_klines(self, **params):
+        """Premium index kline bars of a symbol.l. Klines are uniquely identified by their open time.
+
+        https://binance-docs.github.io/apidocs/futures/en/#premium-index-kline-data
+
+        """
+        return self._request_futures_api("get", "premiumIndexKlines", data=params)
+
     def futures_continous_klines(self, **params):
         """Kline/candlestick bars for a specific contract type. Klines are uniquely identified by their open time.
 

--- a/binance/client.py
+++ b/binance/client.py
@@ -7829,7 +7829,6 @@ class Client(BaseClient):
         """
         return self._request_futures_coin_api("get", "indexPriceKlines", data=params)
 
-
     def futures_coin_premium_index_klines(self, **params):
         """Kline/candlestick bars for the index price of a pair..
 
@@ -7837,7 +7836,6 @@ class Client(BaseClient):
 
         """
         return self._request_futures_coin_api("get", "premiumIndexKlines", data=params)
-
 
     def futures_coin_mark_price_klines(self, **params):
         """Kline/candlestick bars for the index price of a pair..

--- a/binance/enums.py
+++ b/binance/enums.py
@@ -71,6 +71,9 @@ class HistoricalKlinesType(Enum):
     FUTURES = 2
     FUTURES_COIN = 3
     FUTURES_MARK_PRICE = 4
+    FUTURES_INDEX_PRICE = 5
+    FUTURES_COIN_MARK_PRICE = 6
+    FUTURES_COIN_INDEX_PRICE = 7
 
 
 class FuturesType(Enum):

--- a/binance/enums.py
+++ b/binance/enums.py
@@ -70,6 +70,7 @@ class HistoricalKlinesType(Enum):
     SPOT = 1
     FUTURES = 2
     FUTURES_COIN = 3
+    FUTURES_MARK_PRICE = 4
 
 
 class FuturesType(Enum):

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -68,6 +68,7 @@ async def test_futures_index_price_klines(clientAsync):
 async def test_futures_premium_index_klines(clientAsync):
     await clientAsync.futures_premium_index_klines(symbol="BTCUSDT", interval="1h")
 
+
 @pytest.mark.skip(reason="network error")
 async def test_futures_coin_premium_index_klines(clientAsync):
     await clientAsync.futures_coin_premium_index_klines(symbol="BTCUSD", interval="1h")

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -60,8 +60,14 @@ async def test_get_klines(clientAsync):
 async def test_futures_mark_price_klines(clientAsync):
     await clientAsync.futures_mark_price_klines(symbol="BTCUSDT", interval="1h")
 
+
 async def test_futures_index_price_klines(clientAsync):
     await clientAsync.futures_index_price_klines(pair="BTCUSDT", interval="1h")
+
+
+async def test_futures_premium_index_klines(clientAsync):
+    await clientAsync.futures_premium_index_klines(symbol="BTCUSDT", interval="1h")
+
 
 async def test_get_avg_price(clientAsync):
     await clientAsync.get_avg_price(symbol="BTCUSDT")

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -68,6 +68,10 @@ async def test_futures_index_price_klines(clientAsync):
 async def test_futures_premium_index_klines(clientAsync):
     await clientAsync.futures_premium_index_klines(symbol="BTCUSDT", interval="1h")
 
+@pytest.mark.skip(reason="network error")
+async def test_futures_coin_premium_index_klines(clientAsync):
+    await clientAsync.futures_coin_premium_index_klines(symbol="BTCUSD", interval="1h")
+
 
 async def test_get_avg_price(clientAsync):
     await clientAsync.get_avg_price(symbol="BTCUSDT")

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -60,6 +60,8 @@ async def test_get_klines(clientAsync):
 async def test_futures_mark_price_klines(clientAsync):
     await clientAsync.futures_mark_price_klines(symbol="BTCUSDT", interval="1h")
 
+async def test_futures_index_price_klines(clientAsync):
+    await clientAsync.futures_index_price_klines(pair="BTCUSDT", interval="1h")
 
 async def test_get_avg_price(clientAsync):
     await clientAsync.get_avg_price(symbol="BTCUSDT")

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -57,6 +57,10 @@ async def test_get_klines(clientAsync):
     await clientAsync.get_klines(symbol="BTCUSDT", interval="1d")
 
 
+async def test_futures_mark_price_klines(clientAsync):
+    await clientAsync.futures_mark_price_klines(symbol="BTCUSDT", interval="1h")
+
+
 async def test_get_avg_price(clientAsync):
     await clientAsync.get_avg_price(symbol="BTCUSDT")
 

--- a/tests/test_async_client_futures.py
+++ b/tests/test_async_client_futures.py
@@ -598,4 +598,6 @@ async def test_futures_coin_account_trade_history_download(futuresClientAsync):
 
 @pytest.mark.skip(reason="No sandbox support")
 async def test_futures_coin_account_trade_download_id(futuresClientAsync):
-    await futuresClientAsync.futures_coin_account_trade_history_download_link(downloadId="123")
+    await futuresClientAsync.futures_coin_account_trade_history_download_link(
+        downloadId="123"
+    )

--- a/tests/test_client_futures.py
+++ b/tests/test_client_futures.py
@@ -579,9 +579,11 @@ def test_futures_coin_stream_close(futuresClient):
     listen_key = futuresClient.futures_coin_stream_get_listen_key()
     futuresClient.futures_coin_stream_close(listenKey=listen_key)
 
+
 ########################################################
 # Test block trades
 ########################################################
+
 
 @pytest.mark.skip(reason="No sandbox support")
 def test_futures_coin_account_order_history_download(futuresClient):
@@ -643,6 +645,7 @@ def test_futures_coin_account_order_download_id_mock(futuresClient):
             downloadId="123"
         )
         assert response == expected_response
+
 
 def test_futures_coin_account_trade_history_download_id_mock(futuresClient):
     expected_response = {

--- a/tests/test_client_futures.py
+++ b/tests/test_client_futures.py
@@ -48,6 +48,10 @@ def test_futures_index_price_klines(futuresClient):
     futuresClient.futures_index_price_klines(pair="BTCUSDT", interval="1h")
 
 
+def test_futures_premium_index_klines(futuresClient):
+    futuresClient.futures_premium_index_klines(symbol="BTCUSDT", interval="1h")
+
+
 def test_futures_continous_klines(futuresClient):
     futuresClient.futures_continous_klines(
         pair="BTCUSDT", contractType="PERPETUAL", interval="1h"

--- a/tests/test_client_futures.py
+++ b/tests/test_client_futures.py
@@ -44,6 +44,10 @@ def test_futures_mark_price_klines(futuresClient):
     futuresClient.futures_mark_price_klines(symbol="BTCUSDT", interval="1h")
 
 
+def test_futures_index_price_klines(futuresClient):
+    futuresClient.futures_index_price_klines(pair="BTCUSDT", interval="1h")
+
+
 def test_futures_continous_klines(futuresClient):
     futuresClient.futures_continous_klines(
         pair="BTCUSDT", contractType="PERPETUAL", interval="1h"

--- a/tests/test_client_futures.py
+++ b/tests/test_client_futures.py
@@ -40,6 +40,10 @@ def test_futures_klines(futuresClient):
     futuresClient.futures_klines(symbol="BTCUSDT", interval="1h")
 
 
+def test_futures_mark_price_klines(futuresClient):
+    futuresClient.futures_mark_price_klines(symbol="BTCUSDT", interval="1h")
+
+
 def test_futures_continous_klines(futuresClient):
     futuresClient.futures_continous_klines(
         pair="BTCUSDT", contractType="PERPETUAL", interval="1h"


### PR DESCRIPTION
Thank you for the excellent library!  
I noticed that the endpoint for **Mark Price Kline/Candlestick Data** is missing.  
You can refer to this link for more details: [Mark Price Kline/Candlestick Data](https://binance-docs.github.io/apidocs/futures/en/#mark-price-kline-candlestick-data)

