### PR TITLE
feat: fix docs to show all docstrings

### DIFF
--- a/docs/binance.rst
+++ b/docs/binance.rst
@@ -1,7 +1,7 @@
 Binance API
 ===========
 
-client module
+Client module
 -------------
 
 .. automodule:: binance.client
@@ -9,10 +9,34 @@ client module
     :undoc-members:
     :show-inheritance:
 
+Async client module
+-------------------
+
+.. automodule:: binance.async_client
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Websockets module
+-----------------
+
+.. automodule:: binance.ws.streams
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Threaded streams module
+-----------------------
+
+.. automodule:: binance.ws.threaded_stream
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 depthcache module
 -----------------
 
-.. automodule:: binance.depthcache
+.. automodule:: binance.ws.depthcache
     :members:
     :undoc-members:
     :show-inheritance:
@@ -29,14 +53,6 @@ helpers module
 --------------
 
 .. automodule:: binance.helpers
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-websockets module
------------------
-
-.. automodule:: binance.streams
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ release = "0.2.0"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx==8.1.3
 sphinx_rtd_theme==3.0.1
 sphinx-copybutton>=0.5.0
+aiohttp


### PR DESCRIPTION
Fixes docs to include full API reference

Can test locally by: 
```
cd docs
pip install -r requirements.txt
python -m sphinx -T -b html -d _build/doctrees -D language=en . output/html
cd output/html
python -m http.server
```