### PR TITLE
fix: docs requirements

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -33,3 +33,4 @@ sphinx:
 python:
   install:
     - requirements: docs/requirements.txt
+    - requirements: requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
 sphinx==8.1.3
 sphinx_rtd_theme==3.0.1
 sphinx-copybutton>=0.5.0
-aiohttp


### PR DESCRIPTION
**Issue**: Currently docs not generating completly.
**Why**: "sphinx.ext.autodoc" plugin requires to install all dependencies of the project
**Solution**: Have read-the-docs install also project requirements during build

An alternative is to mock all the requirements in the conf.py file, but this would require making sure it is changed anytime requirements.txt is changed.