### PR TITLE
Update Endpoints.md, add futures_taker_longshort_ratio and update tests

### DIFF
--- a/Endpoints.md
+++ b/Endpoints.md
@@ -629,20 +629,25 @@
     client.futures_open_interest(symbol)
     ``` 
   - **GET /futures/data/openInterestHist** (Open Interest Statistics.)
-
-    > :warning: Not yet implemented
+    ```python 
+    client.futures_open_interest_hist(symbol)
+    ``` 
   - **GET /futures/data/topLongShortAccountRatio** (Top Trader Long/Short Ratio (Accounts) (MARKET_DATA).)
-
-    > :warning: Not yet implemented
+    ```python 
+    client.futures_top_longshort_account_ratio(symbol)
+    ``` 
   - **GET /futures/data/topLongShortPositionRatio** (Top Trader Long/Short Ratio (Positions).)
-
-    > :warning: Not yet implemented
+    ```python
+    client.futures_top_longshort_position_ratio(symbol)
+    ```
   - **GET /futures/data/globalLongShortAccountRatio** (Long/Short Ratio.)
-
-    > :warning: Not yet implemented
+    ```python
+    client.futures_global_longshort_ratio(symbol)
+    ```
   - **GET /futures/data/takerlongshortRatio** (Taker Buy/Sell Volume.)
-
-    > :warning: Not yet implemented
+    ```python
+    client.futures_taker_longshort_ratio(symbol)
+    ```
   - **GET /fapi/v1/lvtKlines** (Historical BLVT NAV Kline/Candlestick.)
 
     > :warning: Not yet implemented

--- a/Endpoints.md
+++ b/Endpoints.md
@@ -630,23 +630,23 @@
     ``` 
   - **GET /futures/data/openInterestHist** (Open Interest Statistics.)
     ```python 
-    client.futures_open_interest_hist(symbol)
+    client.futures_open_interest_hist(symbol, period, limit, startTime, endTime)
     ``` 
   - **GET /futures/data/topLongShortAccountRatio** (Top Trader Long/Short Ratio (Accounts) (MARKET_DATA).)
     ```python 
-    client.futures_top_longshort_account_ratio(symbol)
+    client.futures_top_longshort_account_ratio(symbol, period, limit, startTime, endTime)
     ``` 
   - **GET /futures/data/topLongShortPositionRatio** (Top Trader Long/Short Ratio (Positions).)
     ```python
-    client.futures_top_longshort_position_ratio(symbol)
+    client.futures_top_longshort_position_ratio(symbol, period, limit, startTime, endTime)
     ```
   - **GET /futures/data/globalLongShortAccountRatio** (Long/Short Ratio.)
     ```python
-    client.futures_global_longshort_ratio(symbol)
+    client.futures_global_longshort_ratio(symbol, period, limit, startTime, endTime)
     ```
   - **GET /futures/data/takerlongshortRatio** (Taker Buy/Sell Volume.)
     ```python
-    client.futures_taker_longshort_ratio(symbol)
+    client.futures_taker_longshort_ratio(symbol, period, limit, startTime, endTime)
     ```
   - **GET /fapi/v1/lvtKlines** (Historical BLVT NAV Kline/Candlestick.)
 

--- a/binance/async_client.py
+++ b/binance/async_client.py
@@ -1753,6 +1753,11 @@ class AsyncClient(BaseClient):
         return await self._request_futures_data_api(
             "get", "globalLongShortAccountRatio", data=params
         )
+        
+    async def futures_taker_longshort_ratio(self, **params):
+        return await self._request_futures_data_api(
+            "get", "takerlongshortRatio", data=params
+        )
 
     async def futures_ticker(self, **params):
         return await self._request_futures_api("get", "ticker/24hr", data=params)

--- a/binance/client.py
+++ b/binance/client.py
@@ -7270,6 +7270,15 @@ class Client(BaseClient):
         return self._request_futures_data_api(
             "get", "globalLongShortAccountRatio", data=params
         )
+        
+    def futures_taker_longshort_ratio(self, **params):
+        """Get taker buy to sell volume ratio of a specific symbol
+
+        https://developers.binance.com/docs/derivatives/usds-margined-futures/market-data/rest-api/Taker-BuySell-Volume
+        """
+        return self._request_futures_data_api(
+            "get", "takerlongshortRatio", data=params
+        )
 
     def futures_ticker(self, **params):
         """24 hour rolling window price change statistics.

--- a/tests/test_async_client_futures.py
+++ b/tests/test_async_client_futures.py
@@ -66,24 +66,28 @@ async def test_futures_funding_rate(futuresClientAsync):
     await futuresClientAsync.futures_funding_rate()
 
 
+@pytest.mark.skip(reason="No Sandbox Environment to test")
 async def test_futures_top_longshort_account_ratio(futuresClientAsync):
     await futuresClientAsync.futures_top_longshort_account_ratio(
         symbol="BTCUSDT", period="5m"
     )
 
 
+@pytest.mark.skip(reason="No Sandbox Environment to test")
 async def test_futures_top_longshort_position_ratio(futuresClientAsync):
     await futuresClientAsync.futures_top_longshort_position_ratio(
         symbol="BTCUSDT", period="5m"
     )
 
 
+@pytest.mark.skip(reason="No Sandbox Environment to test")
 async def test_futures_global_longshort_ratio(futuresClientAsync):
     await futuresClientAsync.futures_global_longshort_ratio(
         symbol="BTCUSDT", period="5m"
     )
 
 
+@pytest.mark.skip(reason="No Sandbox Environment to test")
 async def test_futures_taker_longshort_ratio(futuresClientAsync):
     await futuresClientAsync.futures_taker_longshort_ratio(
         symbol="BTCUSDT", period="5m"
@@ -130,6 +134,7 @@ async def test_futures_index_info(futuresClientAsync):
     await futuresClientAsync.futures_index_info()
 
 
+@pytest.mark.skip(reason="No Sandbox Environment to test")
 async def test_futures_open_interest_hist(futuresClientAsync):
     await futuresClientAsync.futures_open_interest_hist(symbol="BTCUSDT", period="5m")
 

--- a/tests/test_async_client_futures.py
+++ b/tests/test_async_client_futures.py
@@ -66,19 +66,20 @@ async def test_futures_funding_rate(futuresClientAsync):
     await futuresClientAsync.futures_funding_rate()
 
 
-@pytest.mark.skip(reason="Not implemented")
 async def test_futures_top_longshort_account_ratio(futuresClientAsync):
     await futuresClientAsync.futures_top_longshort_account_ratio()
 
 
-@pytest.mark.skip(reason="Not implemented")
 async def test_futures_top_longshort_position_ratio(futuresClientAsync):
     await futuresClientAsync.futures_top_longshort_position_ratio()
 
 
-@pytest.mark.skip(reason="Not implemented")
 async def test_futures_global_longshort_ratio(futuresClientAsync):
     await futuresClientAsync.futures_global_longshort_ratio()
+
+
+async def test_futures_taker_longshort_ratio(futuresClientAsync):
+    await futuresClientAsync.futures_taker_longshort_ratio()
 
 
 async def test_futures_ticker(futuresClientAsync):
@@ -121,7 +122,6 @@ async def test_futures_index_info(futuresClientAsync):
     await futuresClientAsync.futures_index_info()
 
 
-@pytest.mark.skip(reason="Not implemented")
 async def test_futures_open_interest_hist(futuresClientAsync):
     await futuresClientAsync.futures_open_interest_hist(symbol="BTCUSDT")
 

--- a/tests/test_async_client_futures.py
+++ b/tests/test_async_client_futures.py
@@ -67,19 +67,27 @@ async def test_futures_funding_rate(futuresClientAsync):
 
 
 async def test_futures_top_longshort_account_ratio(futuresClientAsync):
-    await futuresClientAsync.futures_top_longshort_account_ratio()
+    await futuresClientAsync.futures_top_longshort_account_ratio(
+        symbol="BTCUSDT", period="5m"
+    )
 
 
 async def test_futures_top_longshort_position_ratio(futuresClientAsync):
-    await futuresClientAsync.futures_top_longshort_position_ratio()
+    await futuresClientAsync.futures_top_longshort_position_ratio(
+        symbol="BTCUSDT", period="5m"
+    )
 
 
 async def test_futures_global_longshort_ratio(futuresClientAsync):
-    await futuresClientAsync.futures_global_longshort_ratio()
+    await futuresClientAsync.futures_global_longshort_ratio(
+        symbol="BTCUSDT", period="5m"
+    )
 
 
 async def test_futures_taker_longshort_ratio(futuresClientAsync):
-    await futuresClientAsync.futures_taker_longshort_ratio()
+    await futuresClientAsync.futures_taker_longshort_ratio(
+        symbol="BTCUSDT", period="5m"
+    )
 
 
 async def test_futures_ticker(futuresClientAsync):
@@ -123,7 +131,7 @@ async def test_futures_index_info(futuresClientAsync):
 
 
 async def test_futures_open_interest_hist(futuresClientAsync):
-    await futuresClientAsync.futures_open_interest_hist(symbol="BTCUSDT")
+    await futuresClientAsync.futures_open_interest_hist(symbol="BTCUSDT", period="5m")
 
 
 async def test_futures_leverage_bracket(futuresClientAsync):

--- a/tests/test_client_futures.py
+++ b/tests/test_client_futures.py
@@ -78,19 +78,20 @@ def test_futures_funding_rate(futuresClient):
     futuresClient.futures_funding_rate()
 
 
-@pytest.mark.skip(reason="Not implemented")
 def test_futures_top_longshort_account_ratio(futuresClient):
     futuresClient.futures_top_longshort_account_ratio()
 
 
-@pytest.mark.skip(reason="Not implemented")
 def test_futures_top_longshort_position_ratio(futuresClient):
     futuresClient.futures_top_longshort_position_ratio()
 
 
-@pytest.mark.skip(reason="Not implemented")
 def test_futures_global_longshort_ratio(futuresClient):
     futuresClient.futures_global_longshort_ratio()
+
+
+def test_futures_taker_longshort_ratio(futuresClient):
+    futuresClient.futures_taker_longshort_ratio()
 
 
 def test_futures_ticker(futuresClient):
@@ -104,8 +105,10 @@ def test_futures_symbol_ticker(futuresClient):
 def test_futures_orderbook_ticker(futuresClient):
     futuresClient.futures_orderbook_ticker()
 
+
 def test_futures_index_index_price_constituents(futuresClient):
     futuresClient.futures_index_price_constituents(symbol="BTCUSD")
+
 
 def test_futures_liquidation_orders(futuresClient):
     futuresClient.futures_liquidation_orders()
@@ -131,7 +134,6 @@ def test_futures_index_info(futuresClient):
     futuresClient.futures_index_info()
 
 
-@pytest.mark.skip(reason="Not implemented")
 def test_futures_open_interest_hist(futuresClient):
     futuresClient.futures_open_interest_hist(symbol="BTCUSDT")
 
@@ -447,8 +449,10 @@ def test_futures_coin_symbol_ticker(futuresClient):
 def test_futures_coin_orderbook_ticker(futuresClient):
     futuresClient.futures_coin_orderbook_ticker()
 
+
 def test_futures_coin_index_index_price_constituents(futuresClient):
     futuresClient.futures_coin_index_price_constituents(symbol="BTCUSD")
+
 
 @pytest.mark.skip(reason="Not implemented")
 def test_futures_coin_liquidation_orders(futuresClient):

--- a/tests/test_client_futures.py
+++ b/tests/test_client_futures.py
@@ -78,18 +78,22 @@ def test_futures_funding_rate(futuresClient):
     futuresClient.futures_funding_rate()
 
 
+@pytest.mark.skip(reason="No Sandbox Environment to test")
 def test_futures_top_longshort_account_ratio(futuresClient):
     futuresClient.futures_top_longshort_account_ratio(symbol="BTCUSDT", period="5m")
 
 
+@pytest.mark.skip(reason="No Sandbox Environment to test")
 def test_futures_top_longshort_position_ratio(futuresClient):
     futuresClient.futures_top_longshort_position_ratio(symbol="BTCUSDT", period="5m")
 
 
+@pytest.mark.skip(reason="No Sandbox Environment to test")
 def test_futures_global_longshort_ratio(futuresClient):
     futuresClient.futures_global_longshort_ratio(symbol="BTCUSDT", period="5m")
 
 
+@pytest.mark.skip(reason="No Sandbox Environment to test")
 def test_futures_taker_longshort_ratio(futuresClient):
     futuresClient.futures_taker_longshort_ratio(symbol="BTCUSDT", period="5m")
 
@@ -134,6 +138,7 @@ def test_futures_index_info(futuresClient):
     futuresClient.futures_index_info()
 
 
+@pytest.mark.skip(reason="No Sandbox Environment to test")
 def test_futures_open_interest_hist(futuresClient):
     futuresClient.futures_open_interest_hist(symbol="BTCUSDT", period="5m")
 

--- a/tests/test_client_futures.py
+++ b/tests/test_client_futures.py
@@ -79,19 +79,19 @@ def test_futures_funding_rate(futuresClient):
 
 
 def test_futures_top_longshort_account_ratio(futuresClient):
-    futuresClient.futures_top_longshort_account_ratio()
+    futuresClient.futures_top_longshort_account_ratio(symbol="BTCUSDT", period="5m")
 
 
 def test_futures_top_longshort_position_ratio(futuresClient):
-    futuresClient.futures_top_longshort_position_ratio()
+    futuresClient.futures_top_longshort_position_ratio(symbol="BTCUSDT", period="5m")
 
 
 def test_futures_global_longshort_ratio(futuresClient):
-    futuresClient.futures_global_longshort_ratio()
+    futuresClient.futures_global_longshort_ratio(symbol="BTCUSDT", period="5m")
 
 
 def test_futures_taker_longshort_ratio(futuresClient):
-    futuresClient.futures_taker_longshort_ratio()
+    futuresClient.futures_taker_longshort_ratio(symbol="BTCUSDT", period="5m")
 
 
 def test_futures_ticker(futuresClient):
@@ -135,7 +135,7 @@ def test_futures_index_info(futuresClient):
 
 
 def test_futures_open_interest_hist(futuresClient):
-    futuresClient.futures_open_interest_hist(symbol="BTCUSDT")
+    futuresClient.futures_open_interest_hist(symbol="BTCUSDT", period="5m")
 
 
 def test_futures_leverage_bracket(futuresClient):


### PR DESCRIPTION
I saw some APIs are implemented but their statuses are not updated in Endpoints.md. It may be intended to be like that, so correct me if I'm wrong.
I also add `client.futures_taker_longshort_ratio` using **takerlongshortRatio** endpoint from finance.
Finally, I update the tests for all of the above APIs