### PR TITLE
fix: close read loop before closing websocket fix #1530

### DIFF
--- a/binance/ws/reconnecting_websocket.py
+++ b/binance/ws/reconnecting_websocket.py
@@ -95,16 +95,15 @@ class ReconnectingWebsocket:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         self._log.debug(f"Closing Websocket {self._url}{self._prefix}{self._path}")
+        if self._handle_read_loop:
+            await self._kill_read_loop()
         if self._exit_coro:
             await self._exit_coro(self._path)
-        self.ws_state = WSListenerState.EXITING
         if self.ws:
             await self.ws.close()
         if self._conn and hasattr(self._conn, "protocol"):
             await self._conn.__aexit__(exc_type, exc_val, exc_tb)
         self.ws = None
-        if self._handle_read_loop:
-            await self._kill_read_loop()
 
     async def connect(self):
         self._log.debug("Establishing new WebSocket connection")


### PR DESCRIPTION
#### Problem
When closing the BinanceWebsocket in some cases the websocket will close before the readloop, causing the read loop to return to the user a ClosedConnectionError.
#### Solution
- When closing the binanceWebsocket, first the read loop is exited and the websocket is stopped.
- Remove unnecesary line of setting the ws state to Exiting as it's done already inside `_kill_read_loop`