### PR TITLE
fix: return empty json instead of throwing error on empty response

### DIFF
--- a/binance/async_client.py
+++ b/binance/async_client.py
@@ -310,9 +310,12 @@ class AsyncClient(BaseClient):
         params = {}
         if symbol:
             params["symbol"] = symbol
-        return await self._get(
+        response = await self._get(
             "ticker/price", version=self.PRIVATE_API_VERSION, data=params
         )
+        if isinstance(response, list) and all(isinstance(item, dict) for item in response):
+            return response
+        raise TypeError("Expected a list of dictionaries")
 
     get_all_tickers.__doc__ = Client.get_all_tickers.__doc__
 

--- a/binance/async_client.py
+++ b/binance/async_client.py
@@ -161,6 +161,10 @@ class AsyncClient(BaseClient):
         """
         if not str(response.status).startswith("2"):
             raise BinanceAPIException(response, response.status, await response.text())
+        
+        if response.text == "":
+            return {}
+
         try:
             return await response.json()
         except ValueError:

--- a/binance/client.py
+++ b/binance/client.py
@@ -386,7 +386,10 @@ class Client(BaseClient):
         :raises: BinanceRequestException, BinanceAPIException
 
         """
-        return self._get("ticker/price", version=self.PRIVATE_API_VERSION)
+        response = self._get("ticker/price", version=self.PRIVATE_API_VERSION)
+        if isinstance(response, list) and all(isinstance(item, dict) for item in response):
+            return response
+        raise TypeError("Expected a list of dictionaries")
 
     def get_orderbook_tickers(self, **params) -> Dict:
         """Best price/qty on the order book for all symbols.

--- a/binance/client.py
+++ b/binance/client.py
@@ -96,6 +96,10 @@ class Client(BaseClient):
         """
         if not (200 <= response.status_code < 300):
             raise BinanceAPIException(response, response.status_code, response.text)
+        
+        if response.text == "":
+            return {}
+
         try:
             return response.json()
         except ValueError:


### PR DESCRIPTION
### Problem
- Some endpoints return a status.code 200 with an empty response. Here the library was throwing a ValueError.
- Fixes pyright error for get_all_tickers

### Solution
Return an empty json in case of an empty response
