### PR TITLE
fix: ws api not allowing to send over 100 requests

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -33,6 +34,7 @@ jobs:
   build:
     needs: lint
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     env:
       PROXY: "http://51.83.140.52:16301"
       TEST_TESTNET: "true"
@@ -74,6 +76,7 @@ jobs:
     needs: build
     if: ${{ always() }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - name: Coveralls Finished
       uses: coverallsapp/github-action@v2

--- a/binance/ws/websocket_api.py
+++ b/binance/ws/websocket_api.py
@@ -37,10 +37,10 @@ class WebsocketAPI(ReconnectingWebsocket):
                 self._responses[req_id].set_exception(exception)
             else:
                 self._responses[req_id].set_result(parsed_msg)
-        else:
-            if exception is None:
-                exception = Exception(f"Unknown message: {parsed_msg}")
+        elif exception is not None:
             raise exception
+        else:
+            self._log.warning(f"WS api receieved unknown message: {parsed_msg}")
 
     async def _ensure_ws_connection(self) -> None:
         """Ensure WebSocket connection is established and ready

--- a/binance/ws/websocket_api.py
+++ b/binance/ws/websocket_api.py
@@ -21,25 +21,26 @@ class WebsocketAPI(ReconnectingWebsocket):
     def _handle_message(self, msg):
         """Override message handling to support request-response"""
         parsed_msg = super()._handle_message(msg)
+        self._log.debug(f"Received message: {parsed_msg}")
         if parsed_msg is None:
             return None
-        req_id, exception, throwError = None, None, False
+        req_id, exception = None, None
         if "id" in parsed_msg:
             req_id = parsed_msg["id"]
         if "status" in parsed_msg:
             if parsed_msg["status"] != 200:
-                throwError = True
                 exception = BinanceAPIException(
                     parsed_msg, parsed_msg["status"], self.json_dumps(parsed_msg["error"])
                 )
         if req_id is not None and req_id in self._responses:
-            if throwError and exception is not None:
+            if exception is not None:
                 self._responses[req_id].set_exception(exception)
             else:
                 self._responses[req_id].set_result(parsed_msg)
-        elif throwError and exception is not None:
+        else:
+            if exception is None:
+                exception = Exception(f"Unknown message: {parsed_msg}")
             raise exception
-        return parsed_msg
 
     async def _ensure_ws_connection(self) -> None:
         """Ensure WebSocket connection is established and ready

--- a/tests/test_ws_api.py
+++ b/tests/test_ws_api.py
@@ -1,4 +1,5 @@
 import json
+import sys
 import re
 import pytest
 import asyncio
@@ -198,7 +199,7 @@ async def test_ws_queue_overflow(clientAsync):
         # Restore original queue size
         clientAsync.ws_api.MAX_QUEUE_SIZE = original_size
 
-
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="websockets_proxy Python 3.8+")
 @pytest.mark.asyncio
 async def test_ws_api_with_stream(clientAsync):
     """Test combining WebSocket API requests with stream listening"""

--- a/tests/test_ws_api.py
+++ b/tests/test_ws_api.py
@@ -151,3 +151,51 @@ async def test_cleanup_on_exit(clientAsync):
     # Check cleanup
     assert "test" not in clientAsync.ws_api._responses
     assert future.exception() is not None
+
+
+@pytest.mark.asyncio
+async def test_ws_queue_overflow(clientAsync):
+    """WebSocket API should not overflow queue"""
+    # 
+    original_size = clientAsync.ws_api.MAX_QUEUE_SIZE
+    clientAsync.ws_api.MAX_QUEUE_SIZE = 1
+
+    try:
+        # Request multiple order books concurrently
+        symbols = ["BTCUSDT", "ETHUSDT", "BNBUSDT"]
+        tasks = [clientAsync.ws_get_order_book(symbol=symbol) for symbol in symbols]
+        
+        # Execute all requests concurrently and wait for results
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        
+        # Check that we got valid responses or expected overflow errors
+        valid_responses = [r for r in results if not isinstance(r, Exception)]
+        assert len(valid_responses) == len(symbols), "Should get at least one valid response"
+        
+        for result in valid_responses:
+            assert_ob(result)
+            
+    finally:
+        # Restore original queue size
+        clientAsync.ws_api.MAX_QUEUE_SIZE = original_size
+
+
+@pytest.mark.asyncio
+async def test_ws_api_with_stream(clientAsync):
+    """Test combining WebSocket API requests with stream listening"""
+    from binance import BinanceSocketManager
+    
+    # Create socket manager and trade socket
+    bm = BinanceSocketManager(clientAsync)
+    ts = bm.trade_socket("BTCUSDT")
+    
+    async with ts:
+        # Make WS API request while stream is active
+        order_book = await clientAsync.ws_get_order_book(symbol="BTCUSDT")
+        assert_ob(order_book)
+        
+        # Verify we can still receive stream data
+        trade = await ts.recv()
+        assert "s" in trade  # Symbol
+        assert "p" in trade  # Price
+        assert "q" in trade  # Quantity

--- a/tests/test_ws_api.py
+++ b/tests/test_ws_api.py
@@ -120,12 +120,29 @@ async def test_message_handling(clientAsync):
     clientAsync.ws_api._handle_message(json.dumps(valid_msg))
     result = await clientAsync.ws_api._responses["123"]
     assert result == valid_msg
+    
+@pytest.mark.asyncio
+async def test_message_handling_raise_exception(clientAsync):
+    with pytest.raises(BinanceAPIException):
+        future = asyncio.Future()
+        clientAsync.ws_api._responses["123"] = future
+        valid_msg = {"id": "123", "status": 400, "error": {"code": "0", "msg": "error message"}}
+        clientAsync.ws_api._handle_message(json.dumps(valid_msg))
+        await future
+@pytest.mark.asyncio
+async def test_message_handling_raise_exception_without_id(clientAsync):
+    with pytest.raises(BinanceAPIException):
+        future = asyncio.Future()
+        clientAsync.ws_api._responses["123"] = future
+        valid_msg = {"id": "123", "status": 400, "error": {"code": "0", "msg": "error message"}}
+        clientAsync.ws_api._handle_message(json.dumps(valid_msg))
+        await future
+    
+@pytest.mark.asyncio
+async def test_message_handling_invalid_json(clientAsync):
+    with pytest.raises(json.JSONDecodeError):
+        clientAsync.ws_api._handle_message("invalid json")
 
-    # Test message without ID
-    no_id_msg = {"data": "test"}
-    clientAsync.ws_api._handle_message(json.dumps(no_id_msg))
-
-    # Test invalid JSON
     with pytest.raises(json.JSONDecodeError):
         clientAsync.ws_api._handle_message("invalid json")
 

--- a/tests/test_ws_api.py
+++ b/tests/test_ws_api.py
@@ -114,14 +114,16 @@ async def test_testnet_url():
 async def test_message_handling(clientAsync):
     """Test message handling with various message types"""
     # Test valid message
-    valid_msg = {"id": "123", "result": {"test": "data"}}
-    result = clientAsync.ws_api._handle_message(json.dumps(valid_msg))
+    future = asyncio.Future()
+    clientAsync.ws_api._responses["123"] = future
+    valid_msg = {"id": "123", "status": 200, "result": {"test": "data"}}
+    clientAsync.ws_api._handle_message(json.dumps(valid_msg))
+    result = await clientAsync.ws_api._responses["123"]
     assert result == valid_msg
 
     # Test message without ID
     no_id_msg = {"data": "test"}
-    result = clientAsync.ws_api._handle_message(json.dumps(no_id_msg))
-    assert result == no_id_msg
+    clientAsync.ws_api._handle_message(json.dumps(no_id_msg))
 
     # Test invalid JSON
     with pytest.raises(json.JSONDecodeError):


### PR DESCRIPTION
**Problem**: Ws api wasn't allowing to send over 100 requests, as they were being stored in `_queue` and user was not calling _recv(). This was causing the queue to hit the MAX_SIZE

**Solution**: For those messages part of the ws_api there are not put into the recv queue as they are already stored in `_responses` and returned to the user in the future when making the ws_api_request

Note: This would stop any user using `recv()` from receiving `ws_api_request` messages through there. But as the docs don't specify it, and users already receive the message through the future returned by the ws_api_request, I believe this is a safe change.

Fixes #1559

- [x] Added tests