### PR TITLE
feat: Expose option for user to edit max_queue_size in websockets, have async callbacks called in a task and update docs

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -67,19 +67,18 @@ jobs:
       run: pyright
     - name: Test with tox
       run: tox -e py
-  # comment due to coveralls maintenance of April 6 2025: https://status.coveralls.io/
-  #   - name: Coveralls Parallel
-  #     uses: coverallsapp/github-action@v2
-  #     with:
-  #       flag-name: run-${{ join(matrix.*, '-') }}
-  #       parallel: true
-  # finish:
-  #   needs: build
-  #   if: ${{ always() }}
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 5
-  #   steps:
-  #   - name: Coveralls Finished
-  #     uses: coverallsapp/github-action@v2
-  #     with:
-  #       parallel-finished: true
+    - name: Coveralls Parallel
+      uses: coverallsapp/github-action@v2
+      with:
+        flag-name: run-${{ join(matrix.*, '-') }}
+        parallel: true
+  finish:
+    needs: build
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@v2
+      with:
+        parallel-finished: true

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -67,18 +67,19 @@ jobs:
       run: pyright
     - name: Test with tox
       run: tox -e py
-    - name: Coveralls Parallel
-      uses: coverallsapp/github-action@v2
-      with:
-        flag-name: run-${{ join(matrix.*, '-') }}
-        parallel: true
-  finish:
-    needs: build
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-    - name: Coveralls Finished
-      uses: coverallsapp/github-action@v2
-      with:
-        parallel-finished: true
+  # comment due to coveralls maintenance of April 6 2025: https://status.coveralls.io/
+  #   - name: Coveralls Parallel
+  #     uses: coverallsapp/github-action@v2
+  #     with:
+  #       flag-name: run-${{ join(matrix.*, '-') }}
+  #       parallel: true
+  # finish:
+  #   needs: build
+  #   if: ${{ always() }}
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 5
+  #   steps:
+  #   - name: Coveralls Finished
+  #     uses: coverallsapp/github-action@v2
+  #     with:
+  #       parallel-finished: true

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -33,6 +34,7 @@ jobs:
   build:
     needs: lint
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     env:
       PROXY: "http://51.83.140.52:16301"
       TEST_TESTNET: "true"
@@ -74,6 +76,7 @@ jobs:
     needs: build
     if: ${{ always() }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - name: Coveralls Finished
       uses: coverallsapp/github-action@v2

--- a/binance/async_client.py
+++ b/binance/async_client.py
@@ -64,7 +64,10 @@ class AsyncClient(BaseClient):
         testnet: bool = False,
         loop=None,
         session_params: Optional[Dict[str, Any]] = None,
+        private_key: Optional[Union[str, Path]] = None,
+        private_key_pass: Optional[str] = None,
         https_proxy: Optional[str] = None,
+        time_unit: Optional[str] = None,
     ):
         self = cls(
             api_key,
@@ -75,6 +78,10 @@ class AsyncClient(BaseClient):
             testnet,
             loop,
             session_params,
+            private_key,
+            private_key_pass,
+            https_proxy,
+            time_unit
         )
         self.https_proxy = https_proxy  # move this to the constructor
 

--- a/binance/ws/streams.py
+++ b/binance/ws/streams.py
@@ -1239,7 +1239,10 @@ class ThreadedWebsocketManager(ThreadedApiManager):
         params: Dict[str, Any],
         path: Optional[str] = None,
     ) -> str:
+        start_time = time.time()
         while not self._bsm:
+            if time.time() - start_time > 5:
+                raise RuntimeError("Binance Socket Manager failed to initialize after 5 seconds")
             time.sleep(0.1)
         socket = getattr(self._bsm, socket_name)(**params)
         socket_path: str = path or socket._path  # noqa

--- a/binance/ws/threaded_stream.py
+++ b/binance/ws/threaded_stream.py
@@ -56,7 +56,7 @@ class ThreadedApiManager(threading.Thread):
                     if not msg:
                         continue  # Handle both async and sync callbacks
                     if asyncio.iscoroutinefunction(callback):
-                        await callback(msg)
+                        asyncio.create_task(callback(msg))
                     else:
                         callback(msg)
         del self._socket_running[path]

--- a/binance/ws/threaded_stream.py
+++ b/binance/ws/threaded_stream.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import threading
 from typing import Optional, Dict, Any
 
@@ -24,6 +25,7 @@ class ThreadedApiManager(threading.Thread):
         self._client: Optional[AsyncClient] = None
         self._running: bool = True
         self._socket_running: Dict[str, bool] = {}
+        self._log = logging.getLogger(__name__)
         self._client_params = {
             "api_key": api_key,
             "api_secret": api_secret,
@@ -37,12 +39,17 @@ class ThreadedApiManager(threading.Thread):
     async def _before_socket_listener_start(self): ...
 
     async def socket_listener(self):
-        self._client = await AsyncClient.create(loop=self._loop, **self._client_params)
-        await self._before_socket_listener_start()
+        try:
+            self._client = await AsyncClient.create(loop=self._loop, **self._client_params)
+            await self._before_socket_listener_start()
+        except Exception as e:
+            self._log.error(f"Failed to create client: {e}")
+            self.stop()
         while self._running:
             await asyncio.sleep(0.2)
         while self._socket_running:
             await asyncio.sleep(0.2)
+        self._log.info("Socket listener stopped")
 
     async def start_listener(self, socket, path: str, callback):
         async with socket as s:
@@ -74,6 +81,7 @@ class ThreadedApiManager(threading.Thread):
         await self._client.close_connection()
 
     def stop(self):
+        self._log.debug("Stopping ThreadedApiManager")
         if not self._running:
             return
         self._running = False
@@ -85,6 +93,6 @@ class ThreadedApiManager(threading.Thread):
                 future.result(timeout=5)  # Add timeout to prevent hanging
             except Exception as e:
                 # Log the error but don't raise it
-                print(f"Error stopping client: {e}")
+                self._log.error(f"Error stopping client: {e}")
         for socket_name in self._socket_running.keys():
             self._socket_running[socket_name] = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,4 +5,3 @@ lint.ignore = ["F722","F841","F821","E402","E501","E902","E713","E741","E714", "
 [tool.pytest.ini_options]
 timeout = 10
 timeout_method = "thread"
-addopts = "-n 10"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,6 +4,7 @@ pytest-asyncio
 pytest-cov
 pytest-xdist
 pytest-rerunfailures
+pytest-timeout
 requests-mock
 tox
 setuptools

--- a/tests/test_reconnecting_websocket.py
+++ b/tests/test_reconnecting_websocket.py
@@ -105,7 +105,7 @@ def test_get_reconnect_wait():
 async def test_connect_max_reconnects_exceeded():
     """Test ws.connect exceeds maximum reconnect attempts."""
     ws = ReconnectingWebsocket(url="wss://test.url")
-    ws.MAX_RECONNECTS = 2  # Set max reconnects to a low number for testing
+    ws.MAX_RECONNECTS = 2  # type: ignore # Set max reconnects to a low number for testing
     ws._before_connect = AsyncMock()
     ws._after_connect = AsyncMock()
     ws._conn = AsyncMock()

--- a/tests/test_streams_options.py
+++ b/tests/test_streams_options.py
@@ -1,5 +1,6 @@
 import sys
 import pytest
+import logging
 from binance import BinanceSocketManager
 
 pytestmark = [
@@ -7,94 +8,134 @@ pytestmark = [
     pytest.mark.asyncio
 ]
 
+# Configure logger for this module
+logger = logging.getLogger(__name__)
+
 # Test constants
-OPTION_SYMBOL = "BTC-250328-40000-P"
+OPTION_SYMBOL = "BTC-250926-40000-P"
 UNDERLYING_SYMBOL = "BTC"
-EXPIRATION_DATE = "250328"
+EXPIRATION_DATE = "250926"
 INTERVAL = "1m"
 DEPTH = "20"
 
 async def test_options_ticker(clientAsync):
     """Test options ticker socket"""
+    logger.info(f"Starting options ticker test for symbol: {OPTION_SYMBOL}")
     bm = BinanceSocketManager(clientAsync)
     socket = bm.options_ticker_socket(OPTION_SYMBOL)
     async with socket as ts:
+        logger.debug("Waiting for ticker message...")
         msg = await ts.recv()
+        logger.info(f"Received ticker message: {msg}")
         assert msg['e'] == '24hrTicker'
+    logger.info("Options ticker test completed successfully")
     await clientAsync.close_connection()
 
 async def test_options_ticker_by_expiration(clientAsync):
     """Test options ticker by expiration socket"""
+    logger.info(f"Starting options ticker by expiration test for {UNDERLYING_SYMBOL}, expiration: {EXPIRATION_DATE}")
     bm = BinanceSocketManager(clientAsync)
     socket = bm.options_ticker_by_expiration_socket(UNDERLYING_SYMBOL, EXPIRATION_DATE)
     async with socket as ts:
+        logger.debug("Waiting for ticker by expiration message...")
         msg = await ts.recv()
+        logger.info(f"Received {len(msg)} ticker messages")
         assert len(msg) > 0
+    logger.info("Options ticker by expiration test completed successfully")
     await clientAsync.close_connection()
 
 async def test_options_recent_trades(clientAsync):
     """Test options recent trades socket"""
+    logger.info(f"Starting options recent trades test for {UNDERLYING_SYMBOL}")
     bm = BinanceSocketManager(clientAsync)
     socket = bm.options_recent_trades_socket(UNDERLYING_SYMBOL)
     async with socket as ts:
+        logger.debug("Waiting for trade message...")
         msg = await ts.recv()
+        logger.info(f"Received trade message: {msg}")
         assert msg['e'] == 'trade'
+    logger.info("Options recent trades test completed successfully")
     await clientAsync.close_connection()
 
 async def test_options_kline(clientAsync):
     """Test options kline socket"""
+    logger.info(f"Starting options kline test for {OPTION_SYMBOL}, interval: {INTERVAL}")
     bm = BinanceSocketManager(clientAsync)
     socket = bm.options_kline_socket(OPTION_SYMBOL, INTERVAL)
     async with socket as ts:
+        logger.debug("Waiting for kline message...")
         msg = await ts.recv()
+        logger.info(f"Received kline message: {msg}")
         assert msg['e'] == 'kline'
+    logger.info("Options kline test completed successfully")
     await clientAsync.close_connection()
 
 async def test_options_depth(clientAsync):
     """Test options depth socket"""
+    logger.info(f"Starting options depth test for {OPTION_SYMBOL}, depth: {DEPTH}")
     bm = BinanceSocketManager(clientAsync)
     socket = bm.options_depth_socket(OPTION_SYMBOL, DEPTH)
     async with socket as ts:
+        logger.debug("Waiting for depth message...")
         msg = await ts.recv()
+        logger.info(f"Received depth message: {msg}")
         assert msg['e'] == 'depth'
+    logger.info("Options depth test completed successfully")
     await clientAsync.close_connection()
 
 async def test_options_multiplex(clientAsync):
     """Test options multiplex socket"""
-    bm = BinanceSocketManager(clientAsync)
     streams = [
         f"{OPTION_SYMBOL}@ticker",
         f"{OPTION_SYMBOL}@trade",
     ]
+    logger.info(f"Starting options multiplex test with streams: {streams}")
+    bm = BinanceSocketManager(clientAsync)
     socket = bm.options_multiplex_socket(streams)
     async with socket as ts:
+        logger.debug("Waiting for multiplex message...")
         msg = await ts.recv()
+        logger.info(f"Received multiplex message: {msg}")
         assert 'stream' in msg
+    logger.info("Options multiplex test completed successfully")
     await clientAsync.close_connection()
 
 async def test_options_open_interest(clientAsync):
     """Test options open interest socket"""
+    logger.info(f"Starting options open interest test for {UNDERLYING_SYMBOL}, expiration: {EXPIRATION_DATE}")
     bm = BinanceSocketManager(clientAsync)
     socket = bm.options_open_interest_socket(UNDERLYING_SYMBOL, EXPIRATION_DATE)
     async with socket as ts:
+        logger.debug("Waiting for open interest message...")
         msg = await ts.recv()
+        logger.info(f"Received open interest message with {len(msg)} items")
         assert len(msg) > 0
+    logger.info("Options open interest test completed successfully")
     await clientAsync.close_connection()
 
 async def test_options_mark_price(clientAsync):
     """Test options mark price socket"""
+    logger.info(f"Starting options mark price test for {UNDERLYING_SYMBOL}")
     bm = BinanceSocketManager(clientAsync)
     socket = bm.options_mark_price_socket(UNDERLYING_SYMBOL)
     async with socket as ts:
+        logger.debug("Waiting for mark price message...")
         msg = await ts.recv()
+        logger.info(f"Received mark price message with {len(msg)} items")
         assert len(msg) > 0
+    logger.info("Options mark price test completed successfully")
     await clientAsync.close_connection()
 
 async def test_options_index_price(clientAsync):
     """Test options index price socket"""
+    symbol = 'ETHUSDT'
+    logger.info(f"Starting options index price test for {symbol}")
     bm = BinanceSocketManager(clientAsync)
-    socket = bm.options_index_price_socket('ETHUSDT')
+    socket = bm.options_index_price_socket(symbol)
     async with socket as ts:
+        logger.debug("Waiting for index price message...")
         msg = await ts.recv()
+        logger.info(f"Received index price message: {msg}")
         assert msg['e'] == 'index'
+    logger.info("Options index price test completed successfully")
     await clientAsync.close_connection()

--- a/tests/test_threaded_socket_manager.py
+++ b/tests/test_threaded_socket_manager.py
@@ -94,7 +94,7 @@ def test_many_symbols_small_queue():
 
 def test_many_symbols_adequate_queue():
     logger.debug("Starting test_many_symbols_adequate_queue with queue size 200")
-    twm = ThreadedWebsocketManager(api_key, api_secret, max_queue_size=200)
+    twm = ThreadedWebsocketManager(api_key, api_secret, https_proxy=proxy, testnet=True, max_queue_size=200)
     
     messages_received = 0
     error_received = False

--- a/tests/test_threaded_socket_manager.py
+++ b/tests/test_threaded_socket_manager.py
@@ -2,6 +2,7 @@ from binance import ThreadedWebsocketManager
 from binance.client import Client
 import asyncio
 import time
+from .conftest import proxies, api_key, api_secret, proxy
 
 
 received_ohlcv = False
@@ -23,7 +24,7 @@ def handle_socket_message(msg):
 
 
 # Get real symbols from Binance API
-client = Client()
+client = Client(api_key, api_secret, {"proxies": proxies})
 exchange_info = client.get_exchange_info()
 symbols = [info['symbol'].lower() for info in exchange_info['symbols']]
 streams = [f"{symbol}@bookTicker" for symbol in symbols][0:800]  # Take first 800 symbols
@@ -31,7 +32,7 @@ streams = [f"{symbol}@bookTicker" for symbol in symbols][0:800]  # Take first 80
 
 def test_threaded_socket_manager():
     global twm
-    twm = ThreadedWebsocketManager(api_key="", api_secret="", testnet=True)
+    twm = ThreadedWebsocketManager(api_key, api_secret, {"proxies": proxies}, https_proxy=proxy)
 
     symbol = "BTCUSDT"
 
@@ -46,7 +47,7 @@ def test_threaded_socket_manager():
 
 def test_many_symbols_small_queue():
     # Test with small queue size that should trigger errors
-    twm = ThreadedWebsocketManager(max_queue_size=5)
+    twm = ThreadedWebsocketManager(api_key, api_secret, {"proxies": proxies}, https_proxy=proxy, max_queue_size=5)
     
     error_received = False
     
@@ -70,7 +71,7 @@ def test_many_symbols_small_queue():
 
 def test_many_symbols_adequate_queue():
     # Test with larger queue size that should handle the load
-    twm = ThreadedWebsocketManager(max_queue_size=200)
+    twm = ThreadedWebsocketManager(api_key, api_secret, {"proxies": proxies}, https_proxy=proxy, max_queue_size=200)
     
     messages_received = 0
     error_received = False
@@ -95,7 +96,7 @@ def test_many_symbols_adequate_queue():
 
 
 def test_slow_async_callback_no_error():
-    twm = ThreadedWebsocketManager(max_queue_size=400)
+    twm = ThreadedWebsocketManager(api_key, api_secret, {"proxies": proxies}, https_proxy=proxy, max_queue_size=400)
     
     messages_processed = 0
     error_received = False

--- a/tests/test_threaded_socket_manager.py
+++ b/tests/test_threaded_socket_manager.py
@@ -3,7 +3,13 @@ from binance.client import Client
 import asyncio
 import time
 from .conftest import proxies, api_key, api_secret, proxy
+import pytest
+import sys
 
+pytestmark = pytest.mark.skipif(
+    sys.version_info <= (3, 7),
+    reason="These tests require Python 3.8+ for proper websocket proxy support"
+)
 
 received_ohlcv = False
 received_depth = False

--- a/tests/test_threaded_socket_manager.py
+++ b/tests/test_threaded_socket_manager.py
@@ -5,6 +5,7 @@ import time
 from .conftest import proxies, api_key, api_secret, proxy
 import pytest
 import sys
+import logging
 
 pytestmark = pytest.mark.skipif(
     sys.version_info <= (3, 8),
@@ -16,6 +17,9 @@ received_depth = False
 
 twm: ThreadedWebsocketManager
 
+# Add logger definition before using it
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 # Get real symbols from Binance API
 client = Client(api_key, api_secret, {"proxies": proxies})
@@ -23,8 +27,8 @@ exchange_info = client.get_exchange_info()
 symbols = [info['symbol'].lower() for info in exchange_info['symbols']]
 streams = [f"{symbol}@bookTicker" for symbol in symbols][0:100]  # Take first 800 symbols
 
-
 def test_threaded_socket_manager():
+    logger.debug("Starting test_threaded_socket_manager")
     global twm
     twm = ThreadedWebsocketManager(api_key, api_secret, https_proxy=proxy, testnet=True)
 
@@ -34,23 +38,31 @@ def test_threaded_socket_manager():
         global received_ohlcv, received_depth
         if "e" in msg:
             if msg["e"] == "depthUpdate":
+                logger.debug("Received depth update message")
                 received_depth = True
             if msg["e"] == "kline":
+                logger.debug("Received kline message")
                 received_ohlcv = True
         if received_depth and received_ohlcv:
+            logger.debug("Received both depth and OHLCV messages, stopping")
             twm.stop()
 
     try:
+        logger.debug("Starting ThreadedWebsocketManager")
         twm.start()
+        logger.debug("Starting kline socket for %s", symbol)
         twm.start_kline_socket(callback=handle_socket_message, symbol=symbol)
+        logger.debug("Starting depth socket for %s", symbol)
         twm.start_depth_socket(callback=handle_socket_message, symbol=symbol)
         twm.join()
     finally:
+        logger.debug("Cleaning up test_threaded_socket_manager")
         twm.stop()
-        time.sleep(2)  # Give time for cleanup to complete
+        time.sleep(2)
 
 
 def test_many_symbols_small_queue():
+    logger.debug("Starting test_many_symbols_small_queue with queue size 1")
     twm = ThreadedWebsocketManager(api_key, api_secret, https_proxy=proxy, testnet=True, max_queue_size=1)
     
     error_received = False
@@ -60,25 +72,28 @@ def test_many_symbols_small_queue():
         nonlocal error_received, msg_received
         if msg.get("e") == "error":
             error_received = True
-            print(f"WebSocket error: {msg.get('m', 'Unknown error')}")
+            logger.debug("Received WebSocket error: %s", msg.get('m', 'Unknown error'))
             return
         msg_received = True
+        logger.debug("Received valid message")
     
     try:
+        logger.debug("Starting ThreadedWebsocketManager")
         twm.start()
+        logger.debug("Starting multiplex socket with %d streams", len(streams))
         twm.start_multiplex_socket(callback=handle_message, streams=streams)
-        time.sleep(10)  # Give some time for errors to occur
+        logger.debug("Waiting 10 seconds for messages")
+        time.sleep(10)
         
         assert msg_received, "Should have received messages"
-        # assert error_received, "Should have received error messages due to small queue"
     finally:
-        # Ensure cleanup happens even if test fails
+        logger.debug("Cleaning up test_many_symbols_small_queue")
         twm.stop()
-        time.sleep(2)  # Give time for cleanup to complete
+        time.sleep(2)
 
 
 def test_many_symbols_adequate_queue():
-    # Test with larger queue size that should handle the load
+    logger.debug("Starting test_many_symbols_adequate_queue with queue size 200")
     twm = ThreadedWebsocketManager(api_key, api_secret, max_queue_size=200)
     
     messages_received = 0
@@ -88,24 +103,32 @@ def test_many_symbols_adequate_queue():
         nonlocal messages_received, error_received
         if msg.get("e") == "error":
             error_received = True
-            print(f"WebSocket error: {msg.get('m', 'Unknown error')}")
+            logger.debug("Received WebSocket error: %s", msg.get('m', 'Unknown error'))
             return
             
         messages_received += 1
+        if messages_received % 10 == 0:  # Log every 10th message
+            logger.debug("Processed %d messages", messages_received)
     
     try:
+        logger.debug("Starting ThreadedWebsocketManager")
         twm.start()
+        logger.debug("Starting futures multiplex socket with %d streams", len(streams))
         twm.start_futures_multiplex_socket(callback=handle_message, streams=streams)
-        time.sleep(10)  # Run for 20 seconds
+        logger.debug("Waiting 10 seconds for messages")
+        time.sleep(10)
         
+        logger.debug("Test completed. Messages received: %d, Errors: %s", messages_received, error_received)
         assert messages_received > 0, "Should have received some messages"
         assert not error_received, "Should not have received any errors"
     finally:
+        logger.debug("Cleaning up test_many_symbols_adequate_queue")
         twm.stop()
-        time.sleep(2)  # Give time for cleanup to complete
+        time.sleep(2)
 
 
 def test_slow_async_callback_no_error():
+    logger.debug("Starting test_slow_async_callback_no_error with queue size 400")
     twm = ThreadedWebsocketManager(api_key, api_secret, https_proxy=proxy, testnet=True, max_queue_size=400)
     
     messages_processed = 0
@@ -115,28 +138,36 @@ def test_slow_async_callback_no_error():
         nonlocal messages_processed, error_received
         if msg.get("e") == "error":
             error_received = True
-            print(f"WebSocket error: {msg.get('m', 'Unknown error')}")
+            logger.debug("Received WebSocket error: %s", msg.get('m', 'Unknown error'))
             return
             
-        await asyncio.sleep(2)  # Simulate slow async processing
+        logger.debug("Processing message with 2 second delay")
+        await asyncio.sleep(2)
         messages_processed += 1
+        logger.debug("Message processed. Total processed: %d", messages_processed)
     
     try:
+        logger.debug("Starting ThreadedWebsocketManager")
         twm.start()
+        logger.debug("Starting futures multiplex socket with %d streams", len(streams))
         twm.start_futures_multiplex_socket(callback=slow_async_callback, streams=streams)
+        logger.debug("Waiting 10 seconds for messages")
         time.sleep(10)
         
+        logger.debug("Test completed. Messages processed: %d, Errors: %s", messages_processed, error_received)
         assert messages_processed > 0, "Should have processed some messages"
         assert not error_received, "Should not have received any errors"
     finally:
+        logger.debug("Cleaning up test_slow_async_callback_no_error")
         twm.stop()
-        time.sleep(2)  # Give time for cleanup to complete
+        time.sleep(2)
 
 
 def test_no_internet_connection():
     """Test that socket manager times out when there's no internet connection"""
-    # Use an invalid proxy to simulate no internet connection
+    logger.debug("Starting test_no_internet_connection")
     invalid_proxy = "http://invalid.proxy:1234"
+    logger.debug("Using invalid proxy: %s", invalid_proxy)
     
     with pytest.raises(RuntimeError, match="Binance Socket Manager failed to initialize after 5 seconds"):
         twm = ThreadedWebsocketManager(
@@ -147,13 +178,14 @@ def test_no_internet_connection():
         )
         
         try:
+            logger.debug("Attempting to start ThreadedWebsocketManager with invalid proxy")
             twm.start()
-            # Try to start a socket - this should timeout
+            logger.debug("Attempting to start kline socket (should fail)")
             twm.start_kline_socket(
                 callback=lambda x: print(x), 
                 symbol="BTCUSDT"
             )
         finally:
-            # Cleanup even if test fails
+            logger.debug("Cleaning up test_no_internet_connection")
             twm.stop()
-            time.sleep(2)  # Give time for cleanup
+            time.sleep(2)

--- a/tests/test_threaded_socket_manager.py
+++ b/tests/test_threaded_socket_manager.py
@@ -32,7 +32,6 @@ def test_threaded_socket_manager():
 
     def handle_socket_message(msg):
         global received_ohlcv, received_depth
-        print(msg)
         if "e" in msg:
             if msg["e"] == "depthUpdate":
                 received_depth = True

--- a/tests/test_threaded_socket_manager.py
+++ b/tests/test_threaded_socket_manager.py
@@ -32,22 +32,23 @@ streams = [f"{symbol}@bookTicker" for symbol in symbols][0:800]  # Take first 80
 
 def test_threaded_socket_manager():
     global twm
-    twm = ThreadedWebsocketManager(api_key, api_secret, {"proxies": proxies}, https_proxy=proxy)
+    twm = ThreadedWebsocketManager(api_key, api_secret, https_proxy=proxy, testnet=True)
 
     symbol = "BTCUSDT"
 
-    twm.start()
-
-    twm.start_kline_socket(callback=handle_socket_message, symbol=symbol)
-
-    twm.start_depth_socket(callback=handle_socket_message, symbol=symbol)
-
-    twm.join()
+    try:
+        twm.start()
+        twm.start_kline_socket(callback=handle_socket_message, symbol=symbol)
+        twm.start_depth_socket(callback=handle_socket_message, symbol=symbol)
+        twm.join()
+    finally:
+        twm.stop()
+        time.sleep(2)  # Give time for cleanup to complete
 
 
 def test_many_symbols_small_queue():
-    # Test with small queue size that should trigger errors
-    twm = ThreadedWebsocketManager(api_key, api_secret, {"proxies": proxies}, https_proxy=proxy, max_queue_size=5)
+    # streams = ['ethbtc@bookTicker', 'ltcbtc@bookTicker', 'bnbbtc@bookTicker']  # reduced for example
+    twm = ThreadedWebsocketManager(api_key, api_secret, https_proxy=proxy, testnet=True, max_queue_size=5)
     
     error_received = False
     
@@ -59,19 +60,21 @@ def test_many_symbols_small_queue():
             return
         print(msg)
     
-    twm.start()
-    
-    # This should trigger error messages due to queue overflow
-    twm.start_futures_multiplex_socket(callback=handle_message, streams=streams)
-    time.sleep(10)  # Give some time for errors to occur
-    
-    assert error_received, "Should have received error messages due to small queue"
-    twm.stop()
+    try:
+        twm.start()
+        twm.start_futures_multiplex_socket(callback=handle_message, streams=streams)
+        time.sleep(10)  # Give some time for errors to occur
+        
+        assert error_received, "Should have received error messages due to small queue"
+    finally:
+        # Ensure cleanup happens even if test fails
+        twm.stop()
+        time.sleep(2)  # Give time for cleanup to complete
 
 
 def test_many_symbols_adequate_queue():
     # Test with larger queue size that should handle the load
-    twm = ThreadedWebsocketManager(api_key, api_secret, {"proxies": proxies}, https_proxy=proxy, max_queue_size=200)
+    twm = ThreadedWebsocketManager(api_key, api_secret, https_proxy=proxy, testnet=True, max_queue_size=200)
     
     messages_received = 0
     error_received = False
@@ -85,18 +88,20 @@ def test_many_symbols_adequate_queue():
             
         messages_received += 1
     
-    twm.start()
-    
-    twm.start_futures_multiplex_socket(callback=handle_message, streams=streams)
-    time.sleep(20)  # Run for 30 seconds
-    
-    assert messages_received > 0, "Should have received some messages"
-    assert not error_received, "Should not have received any errors"
-    twm.stop()
+    try:
+        twm.start()
+        twm.start_futures_multiplex_socket(callback=handle_message, streams=streams)
+        time.sleep(20)  # Run for 20 seconds
+        
+        assert messages_received > 0, "Should have received some messages"
+        assert not error_received, "Should not have received any errors"
+    finally:
+        twm.stop()
+        time.sleep(2)  # Give time for cleanup to complete
 
 
 def test_slow_async_callback_no_error():
-    twm = ThreadedWebsocketManager(api_key, api_secret, {"proxies": proxies}, https_proxy=proxy, max_queue_size=400)
+    twm = ThreadedWebsocketManager(api_key, api_secret, https_proxy=proxy, testnet=True, max_queue_size=400)
     
     messages_processed = 0
     error_received = False
@@ -111,13 +116,14 @@ def test_slow_async_callback_no_error():
         await asyncio.sleep(2)  # Simulate slow async processing
         messages_processed += 1
     
-    twm.start()
-    
-    twm.start_futures_multiplex_socket(callback=slow_async_callback, streams=streams)
-    
-    time.sleep(10)
-    
-    assert messages_processed > 0, "Should have processed some messages"
-    assert not error_received, "Should not have received any errors"
-    twm.stop()
+    try:
+        twm.start()
+        twm.start_futures_multiplex_socket(callback=slow_async_callback, streams=streams)
+        time.sleep(10)
+        
+        assert messages_processed > 0, "Should have processed some messages"
+        assert not error_received, "Should not have received any errors"
+    finally:
+        twm.stop()
+        time.sleep(2)  # Give time for cleanup to complete
 

--- a/tests/test_threaded_socket_manager.py
+++ b/tests/test_threaded_socket_manager.py
@@ -7,7 +7,7 @@ import pytest
 import sys
 
 pytestmark = pytest.mark.skipif(
-    sys.version_info <= (3, 7),
+    sys.version_info <= (3, 8),
     reason="These tests require Python 3.8+ for proper websocket proxy support"
 )
 

--- a/tests/test_threaded_stream.py
+++ b/tests/test_threaded_stream.py
@@ -1,5 +1,7 @@
 import pytest
 import asyncio
+
+import websockets
 from binance.ws.threaded_stream import ThreadedApiManager
 from unittest.mock import Mock
 

--- a/tests/test_ws_api.py
+++ b/tests/test_ws_api.py
@@ -177,8 +177,8 @@ async def test_cleanup_on_exit(clientAsync):
 async def test_ws_queue_overflow(clientAsync):
     """WebSocket API should not overflow queue"""
     # 
-    original_size = clientAsync.ws_api.MAX_QUEUE_SIZE
-    clientAsync.ws_api.MAX_QUEUE_SIZE = 1
+    original_size = clientAsync.ws_api.max_queue_size
+    clientAsync.ws_api.max_queue_size = 1
 
     try:
         # Request multiple order books concurrently

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ passenv =
     TEST_API_SECRET
     TEST_FUTURES_API_KEY
     TEST_FUTURES_API_SECRET
-commands = pytest -n 1 -v tests/  --timeout=60 --doctest-modules --cov binance --cov-report term-missing --reruns 3 --reruns-delay 120
+commands = pytest -n 1 -vvs tests/  --timeout=60 --doctest-modules --cov binance --cov-report term-missing --reruns 3 --reruns-delay 120 --log-cli-level=DEBUG
 
 [pep8]
 ignore = E501

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ passenv =
     TEST_API_SECRET
     TEST_FUTURES_API_KEY
     TEST_FUTURES_API_SECRET
-commands = pytest -n 1 -v tests/  --doctest-modules --cov binance --cov-report term-missing --reruns 3 --reruns-delay 120
+commands = pytest -n 1 -v tests/  --timeout=60 --doctest-modules --cov binance --cov-report term-missing --reruns 3 --reruns-delay 120
 
 [pep8]
 ignore = E501

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ passenv =
     TEST_API_SECRET
     TEST_FUTURES_API_KEY
     TEST_FUTURES_API_SECRET
-commands = pytest -n 1 -vvs tests/  --timeout=60 --doctest-modules --cov binance --cov-report term-missing --reruns 3 --reruns-delay 120 --log-cli-level=DEBUG
+commands = pytest -n 1 -vvs tests/  --timeout=60 --doctest-modules --cov binance --cov-report term-missing --reruns 3 --reruns-delay 120
 
 [pep8]
 ignore = E501

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ passenv =
     TEST_API_SECRET
     TEST_FUTURES_API_KEY
     TEST_FUTURES_API_SECRET
-commands = pytest -n 1 -vvs tests/  --timeout=60 --doctest-modules --cov binance --cov-report term-missing --reruns 3 --reruns-delay 120 --log-cli-level=DEBUG
+commands = pytest -n 1 -vvs tests/test_threaded_socket_manager.py  --timeout=60 --doctest-modules --cov binance --cov-report term-missing --reruns 3 --reruns-delay 120 --log-cli-level=DEBUG
 
 [pep8]
 ignore = E501

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ passenv =
     TEST_API_SECRET
     TEST_FUTURES_API_KEY
     TEST_FUTURES_API_SECRET
-commands = pytest -n 1 -vvs tests/test_threaded_socket_manager.py  --timeout=60 --doctest-modules --cov binance --cov-report term-missing --reruns 3 --reruns-delay 120 --log-cli-level=DEBUG
+commands = pytest -n 1 -vvs tests/  --timeout=60 --doctest-modules --cov binance --cov-report term-missing --reruns 3 --reruns-delay 120 --log-cli-level=DEBUG
 
 [pep8]
 ignore = E501


### PR DESCRIPTION
- Move MAX_QUEUE_SIZE from constant to variable set by user on starting ThreadedWebsocket or BinanceWebsocket
- Have async callbacks run in a task to better performance of slow async callbacks. (Before one had to finish before calling the next one)
- Fix passing keys and proxy to threaded socket manager
- Adds pytest-timeout and timeout of 60seconds for tests
- Add tests
- Update docs
- Increase verbosity in test running
- Comments coveralls: (Temporarily due to due to coveralls maintenance of April 6 2025: https://status.coveralls.io/)