### PR TITLE
fixed a deprecation warning in helpers.py

### DIFF
--- a/binance/helpers.py
+++ b/binance/helpers.py
@@ -6,7 +6,7 @@ from typing import Union, Optional, Dict
 import dateparser
 import pytz
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from binance.exceptions import UnknownDateFormat
 
@@ -21,7 +21,7 @@ def date_to_milliseconds(date_str: str) -> int:
     :param date_str: date in readable format, i.e. "January 01, 2018", "11 hours ago UTC", "now UTC"
     """
     # get epoch value in UTC
-    epoch: datetime = datetime.utcfromtimestamp(0).replace(tzinfo=pytz.utc)
+    epoch: datetime = datetime.fromtimestamp(0,timezone.utc)
     # parse our date string
     d: Optional[datetime] = dateparser.parse(date_str, settings={"TIMEZONE": "UTC"})
     if not d:


### PR DESCRIPTION
datetime.datetime.utcfromtimestamp() will be deprecated in future versions