### PR TITLE
[depthcache] Propagate exception to user instead of catching and silently failing

### DIFF
--- a/binance/ws/depthcache.py
+++ b/binance/ws/depthcache.py
@@ -188,15 +188,8 @@ class BaseDepthCacheManager:
         await self._socket.__aexit__(*args, **kwargs)
 
     async def recv(self):
-        dc = None
-        while not dc:
-            try:
-                res = await asyncio.wait_for(self._socket.recv(), timeout=self.TIMEOUT)
-            except Exception as e:
-                self._log.warning(e)
-            else:
-                dc = await self._depth_event(res)
-        return dc
+        res = await asyncio.wait_for(self._socket.recv(), timeout=self.TIMEOUT)
+        return await self._depth_event(res)
 
     async def _init_cache(self):
         """Initialise the depth cache calling REST endpoint


### PR DESCRIPTION
This error occurs frequently whilst using the DepthCacheManager
`2025-04-14 01:06:23.479 binance.ws.reconnecting_websocket ERROR [MainThread] [_read_loop] BinanceWebsocketClosed (Connection closed. Reconnecting...)`


The code takes too long to reconnect and in that time the message queue fills up and you get an BinanceWebsocketQueueOverflow exception
`2025-04-14 01:07:02.926 binance.ws.reconnecting_websocket ERROR [MainThread] [_read_loop] Unknown exception (Message queue size 100 exceeded maximum 100)`

All exceptions are caught internally by the library so the user can't automatically reconnect (this should really be fixed in the ReconnectingWebsocket but I don't know enough about all the various use cases to comment.
Instead, what happens is this repeatedly
`2025-04-14 01:08:07.641 binance.ws.depthcache WARNING [MainThread] [recv]`
`2025-04-14 01:08:07.641 binance.ws.depthcache WARNING [MainThread] [recv]`
`2025-04-14 01:08:07.641 binance.ws.depthcache WARNING [MainThread] [recv]`
`2025-04-14 01:08:07.641 binance.ws.depthcache WARNING [MainThread] [recv]`
...

This change just propagates the exception while reading off the queue to the user so that they can reconnect themselves