### PR TITLE
Improve error handling for depth manager

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -33,6 +34,7 @@ jobs:
   build:
     needs: lint
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     env:
       PROXY: "http://51.83.140.52:16301"
       TEST_TESTNET: "true"
@@ -74,6 +76,7 @@ jobs:
     needs: build
     if: ${{ always() }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - name: Coveralls Finished
       uses: coverallsapp/github-action@v2

--- a/docs/depth_cache.rst
+++ b/docs/depth_cache.rst
@@ -153,6 +153,31 @@ Websocket Errors
 ----------------
 
 If the underlying websocket is disconnected and is unable to reconnect None is returned for the depth_cache parameter.
+If the underlying websocket is disconnected an error msg is passed to the callback and to recv() containing the error message.
+In the case the BinanceWebsocketClosed is returned, the websocket will attempt to reconnect 5 times before returning a BinanceUnableToConnect error.
+Example:
+
+.. code:: python
+
+            depth_cache = await dcm.recv()
+            if isinstance(depth_cache, dict) and depth_cache.get('e') == 'error':
+                logger.error(f"Received depth cache error in callback: {depth_cache}")
+                if type == 'BinanceWebsocketClosed':
+                    # ignore as attempts to reconnect
+                    continue
+                break
+
+.. code:: python
+            def handle_depth_cache(depth_cache):
+                if isinstance(depth_cache, dict) and depth_cache.get('e') == 'error':
+                    logger.error(f"Received depth cache error in callback: {depth_cache}")
+                    type = depth_cache.get('type')
+                    if type == 'BinanceWebsocketClosed':
+                        # Automatically attempts to reconnect
+                        return
+                    dcm.stop()
+                    return
+                # handle non error cases here
 
 Examples
 --------

--- a/examples/depth_cache_example.py
+++ b/examples/depth_cache_example.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(root)
+
+import asyncio
+import logging
+from binance import AsyncClient
+from binance.ws.depthcache import DepthCacheManager, DepthCache
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+async def main():
+    # Initialize the client
+    client = await AsyncClient.create()
+
+    # Symbol to monitor
+    symbol = 'BTCUSDT'
+    
+    # Create a depth cache manager instance
+    async with DepthCacheManager(
+        client=client,
+        symbol=symbol,
+    ) as dcm:
+        logger.info(f"Started depth cache for {symbol}")
+        
+        # Monitor depth cache updates for 1 minute
+        for _ in range(100):  # 6 iterations * 10 seconds = 1 minute
+            depth_cache = await dcm.recv()
+            if isinstance(depth_cache, dict) and depth_cache.get('e') == 'error':
+                logger.error(f"Received depth cache error in callback: {depth_cache}")
+                if type == 'BinanceWebsocketClosed':
+                    # ignore as attempts to reconnect
+                    continue
+                break
+            
+            # Get current bids and asks
+            bids = depth_cache.get_bids()[:5]  # Top 5 bids
+            asks = depth_cache.get_asks()[:5]  # Top 5 asks
+            
+            logger.info("Top 5 bids:")
+            for bid in bids:
+                logger.info(f"Price: {bid[0]}, Quantity: {bid[1]}")
+            
+            logger.info("Top 5 asks:")
+            for ask in asks:
+                logger.info(f"Price: {ask[0]}, Quantity: {ask[1]}")
+            
+            logger.info(f"Last update time: {depth_cache.update_time}")
+                
+    # Close the client
+    await client.close_connection()
+
+if __name__ == '__main__':
+    # Run the async example
+    asyncio.run(main())

--- a/examples/depth_cache_example.py
+++ b/examples/depth_cache_example.py
@@ -9,7 +9,7 @@ sys.path.append(root)
 import asyncio
 import logging
 from binance import AsyncClient
-from binance.ws.depthcache import DepthCacheManager, DepthCache
+from binance.ws.depthcache import DepthCacheManager 
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)

--- a/examples/depth_cache_threaded_example.py
+++ b/examples/depth_cache_threaded_example.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-import time
 
 root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(root)

--- a/examples/depth_cache_threaded_example.py
+++ b/examples/depth_cache_threaded_example.py
@@ -24,6 +24,7 @@ def main():
                 if type == 'BinanceWebsocketClosed':
                     # Automatically attempts to reconnect
                     return
+                logger.error(f"Error received - Closing depth cache: {depth_cache}")
                 dcm.stop()
                 return
                  

--- a/examples/depth_cache_threaded_example.py
+++ b/examples/depth_cache_threaded_example.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+
+root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(root)
+
+import logging
+from binance.ws.depthcache import ThreadedDepthCacheManager
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+def main():
+        dcm = ThreadedDepthCacheManager()
+        dcm.start()
+        
+        def handle_depth_cache(depth_cache):
+            if isinstance(depth_cache, dict) and depth_cache.get('e') == 'error':
+                logger.error(f"Received depth cache error in callback: {depth_cache}")
+                type = depth_cache.get('type')
+                if type == 'BinanceWebsocketClosed':
+                    # Automatically attempts to reconnect
+                    return
+                dcm.stop()
+                return
+                 
+            logger.info(f"symbol {depth_cache.symbol}")
+            logger.info(depth_cache.get_bids()[:5])
+            
+        dcm.start_depth_cache(handle_depth_cache, symbol='BNBBTC')
+        dcm.join()
+
+
+if __name__ == "__main__":
+   main()


### PR DESCRIPTION
### Problem:
 - Currently the depth manager if the underlying socket closes, does not notify the user
 - No error was returned on a cancelled loop

### Solution
- Improves error handling for depth manager and threaded manager.
- Notifies user in the case of a disconnect and allows the user to ignore so websocket automatically reconnects
- Improved logging
- Add docs for error handling
- Added examples for both depth manager and  threaded depth manager

Note for backward compatibility: Previous users were told to expect to recieve a None in case of an error and now we are returning a message containing an error