### PR TITLE
Address deprecation

### DIFF
--- a/binance/helpers.py
+++ b/binance/helpers.py
@@ -96,7 +96,7 @@ def get_loop():
         loop = asyncio.get_running_loop()
         return loop
     except RuntimeError as e:
-        if str(e).endswith("no running event loop"):
+        if str(e) == "no running event loop":
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
             return loop


### PR DESCRIPTION
Addresses https://github.com/sammchardy/python-binance/issues/1597

According to the [asyncio eventloop documentation](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop) the `get_event_loop()` was deprecated in version 3.12 and it recommends using the `get_running_loop()` method instead.

Failure to find a `loop` with `asyncio.get_running_loop()` throws a `RunTimeError`. The expected error string was updated