### PR TITLE
Fix: Remove duplicate import and improve type checking

### DIFF
--- a/binance/__init__.py
+++ b/binance/__init__.py
@@ -13,7 +13,6 @@ from binance.ws.depthcache import (
     OptionsDepthCacheManager,  # noqa
     ThreadedDepthCacheManager,  # noqa
     FuturesDepthCacheManager,  # noqa
-    OptionsDepthCacheManager,  # noqa
 )
 from binance.ws.streams import (
     BinanceSocketManager,  # noqa

--- a/binance/helpers.py
+++ b/binance/helpers.py
@@ -76,7 +76,7 @@ def round_step_size(
 def convert_ts_str(ts_str):
     if ts_str is None:
         return ts_str
-    if type(ts_str) == int:
+    if isinstance(ts_str, int):
         return ts_str
     return date_to_milliseconds(ts_str)
 


### PR DESCRIPTION
## Description
This PR addresses two code quality issues found during codebase review:

## Changes
1. **Remove duplicate import** - `OptionsDepthCacheManager` was imported twice in [binance/__init__.py](cci:7://file:///d:/Ninja_Work/Git_work/python-binance/binance/__init__.py:0:0-0:0) (lines 13 and 16)
2. **Improve type checking** - Replaced `type(ts_str) == int` with `isinstance(ts_str, int)` in [helpers.py](cci:7://file:///d:/Ninja_Work/Git_work/python-binance/binance/helpers.py:0:0-0:0) for better Python practices

## Why?
- Duplicate imports are redundant and can cause confusion
- `isinstance()` is the Pythonic way to check types and respects inheritance, while `type()` comparison does not

## Testing
- [x] Existing tests pass
- [x] No breaking changes
- [x] Code follows project style guidelines