### PR TITLE
feat: add USDⓈ-M Futures algo order endpoints for conditional orders migration

### DIFF
--- a/binance/async_client.py
+++ b/binance/async_client.py
@@ -1893,7 +1893,7 @@ class AsyncClient(BaseClient):
         return await self._request_futures_api("post", "order", True, data=params)
 
     async def futures_create_algo_order(self, **params):
-        return await self._request_futures_api('post', 'algoOrder', True, data=params)
+        return await self._request_futures_api("post", "algoOrder", True, data=params)
 
     async def futures_limit_order(self, **params):
         """Send in a new futures limit order.

--- a/binance/client.py
+++ b/binance/client.py
@@ -7970,7 +7970,7 @@ class Client(BaseClient):
         return self._request_futures_api("get", "openAlgoOrders", True, data=params)
 
     def futures_get_all_algo_orders(self, **params):
-        """Get all algo orders; active, CANCELED, TRIGGERED or FINISHED
+        """Get all algo orders; active, CANCELED, TRIGGERED or FINISHED.
 
         https://developers.binance.com/docs/derivatives/usds-margined-futures/trade/rest-api/Query-All-Algo-Orders
 


### PR DESCRIPTION
Add USDⓈ-M Futures algo order endpoints for Binance migration

Adds the 6 new algo order methods needed for Binance's conditional orders migration to Algo Service (effective Dec 2, 2025).

New methods:
- futures_create_algo_order
- futures_cancel_algo_order
- futures_cancel_all_open_algo_orders  
- futures_get_algo_order
- futures_get_open_algo_orders
- futures_get_all_algo_orders

Both sync and async clients included. Follows existing patterns.