### PR TITLE
fix: re-subscribe to user data stream after ws_api reconnect

### DIFF
--- a/binance/ws/keepalive_websocket.py
+++ b/binance/ws/keepalive_websocket.py
@@ -45,6 +45,7 @@ class KeepAliveWebsocket(ReconnectingWebsocket):
             # Unregister the queue from ws_api before unsubscribing
             if hasattr(self._client, "ws_api") and self._client.ws_api:
                 self._client.ws_api.unregister_subscription_queue(self._subscription_id)
+                self._client.ws_api.remove_reconnect_callback(self._handle_reconnect)
             await self._unsubscribe_from_user_data_stream()
         if self._uses_ws_api_subscription:
             # For ws_api subscriptions, we don't manage the connection
@@ -72,6 +73,7 @@ class KeepAliveWebsocket(ReconnectingWebsocket):
             self._client.ws_api.register_subscription_queue(
                 self._subscription_id, self._queue
             )
+            self._client.ws_api.add_reconnect_callback(self._handle_reconnect)
             self._path = f"user_subscription:{self._subscription_id}"
             return
         if self._keepalive_type == "margin":
@@ -86,6 +88,7 @@ class KeepAliveWebsocket(ReconnectingWebsocket):
             self._client.ws_api.register_subscription_queue(
                 self._subscription_id, self._queue
             )
+            self._client.ws_api.add_reconnect_callback(self._handle_reconnect)
             self._path = f"margin_subscription:{self._subscription_id}"
             return
         # Check if this is isolated margin (when keepalive_type is a symbol string)
@@ -111,6 +114,7 @@ class KeepAliveWebsocket(ReconnectingWebsocket):
             self._client.ws_api.register_subscription_queue(
                 self._subscription_id, self._queue
             )
+            self._client.ws_api.add_reconnect_callback(self._handle_reconnect)
             self._path = f"isolated_margin_subscription:{self._subscription_id}"
             return
         if not self._listen_key:
@@ -208,6 +212,76 @@ class KeepAliveWebsocket(ReconnectingWebsocket):
             "userDataStream.subscribe.listenToken", signed=False, params=params
         )
         return response.get("subscriptionId")
+
+    async def _handle_reconnect(self, ws, ws_api):
+        """Called by WebsocketAPI after reconnect to restore subscription."""
+        if not self._uses_ws_api_subscription:
+            return
+
+        old_subscription_id = self._subscription_id
+        try:
+            payload = await self._build_subscribe_payload()
+            await ws.send(ws_api.json_dumps(payload))
+            res = await asyncio.wait_for(ws.recv(), timeout=self.TIMEOUT)
+            res = ws_api.json_loads(res)
+
+            if "error" in res:
+                self._log.error(f"Re-subscribe failed: {res}")
+                return
+
+            new_sub_id = res.get("result", {}).get("subscriptionId")
+            if new_sub_id is None:
+                self._log.error(f"Re-subscribe response missing subscriptionId: {res}")
+                return
+
+            if old_subscription_id is not None:
+                ws_api.unregister_subscription_queue(old_subscription_id)
+            ws_api.register_subscription_queue(new_sub_id, self._queue)
+            self._subscription_id = new_sub_id
+
+            if self._keepalive_type == "user":
+                self._path = f"user_subscription:{new_sub_id}"
+            elif self._keepalive_type == "margin":
+                self._path = f"margin_subscription:{new_sub_id}"
+            else:
+                self._path = f"isolated_margin_subscription:{new_sub_id}"
+
+            self._log.info(f"Re-subscribed after reconnect: {old_subscription_id} -> {new_sub_id}")
+        except Exception as e:
+            self._log.error(f"Failed to re-subscribe after reconnect: {e}")
+
+    async def _build_subscribe_payload(self):
+        """Build a payload for subscribing."""
+        new_id = str(uuid.uuid4())
+        if self._keepalive_type == "user":
+            params = self._client._sign_ws_params(
+                {}, self._client._generate_ws_api_signature
+            )
+            return {
+                "id": new_id,
+                "method": "userDataStream.subscribe.signature",
+                "params": params,
+            }
+        if self._keepalive_type == "margin":
+            token_response = await self._client.margin_create_listen_token(
+                is_isolated=False
+            )
+            self._listen_token_expiration = token_response.get("expirationTime")
+            return {
+                "id": new_id,
+                "method": "userDataStream.subscribe.listenToken",
+                "params": {"listenToken": token_response["token"]},
+            }
+        # isolated margin
+        token_response = await self._client.margin_create_listen_token(
+            symbol=self._keepalive_type, is_isolated=True
+        )
+        self._listen_token_expiration = token_response.get("expirationTime")
+        return {
+            "id": new_id,
+            "method": "userDataStream.subscribe.listenToken",
+            "params": {"listenToken": token_response["token"]},
+        }
 
     async def _unsubscribe_from_user_data_stream(self):
         """Unsubscribe from user data stream using WebSocket API"""

--- a/binance/ws/websocket_api.py
+++ b/binance/ws/websocket_api.py
@@ -16,6 +16,7 @@ class WebsocketAPI(ReconnectingWebsocket):
         self._connection_lock: Optional[asyncio.Lock] = None
         # Subscription queues for routing user data stream events
         self._subscription_queues: Dict[str, asyncio.Queue] = {}
+        self._on_reconnect_callbacks = []
         super().__init__(url=url, prefix="", path="", is_binary=False, https_proxy=https_proxy)
 
     def register_subscription_queue(self, subscription_id: str, queue: asyncio.Queue) -> None:
@@ -25,6 +26,17 @@ class WebsocketAPI(ReconnectingWebsocket):
     def unregister_subscription_queue(self, subscription_id: str) -> None:
         """Unregister a subscription queue."""
         self._subscription_queues.pop(subscription_id, None)
+
+    def add_reconnect_callback(self, callback) -> None:
+        self._on_reconnect_callbacks.append(callback)
+
+    def remove_reconnect_callback(self, callback) -> None:
+        if callback in self._on_reconnect_callbacks:
+            self._on_reconnect_callbacks.remove(callback)
+
+    async def _after_connect(self):
+        for cb in self._on_reconnect_callbacks:
+            await cb(self.ws, self)
 
     @property
     def connection_lock(self) -> asyncio.Lock:


### PR DESCRIPTION
When the ws_api WebSocket connection drops and reconnects, subscriptions (user / margin / isolated margin) are not restored. recv() hangs indefinitely because no events are delivered on the new connection — Binance has no knowledge of the previous subscription.

### How to reproduce

```
client = await AsyncClient.create(api_key=..., api_secret=..., demo=True)
bm = BinanceSocketManager(client, verbose=True)
ts = bm.user_socket()
async with ts as tscm:
    while True:
        res = await tscm.recv()
        print(res)
```

Turn off the network interface for about a minute and bringit back up or terminate ws (13.193.130.223 and 54.64.240.170 are Binance demo ips):
`sudo ss -K -t dst 13.193.130.223 or dst 54.64.240.170`

### Changes

To fix the problem, I added a callback mechanism to WebsocketAPI: add_reconnect_callback() / remove_reconnect_callback()
Overridden _after_connect()  fires all registered callbacks

KeepAliveWebsocket - added re-subscribe logic:
 _handle_reconnect(ws, ws_api) - builds a fresh signed payload, sends it directly via ws.send() / ws.recv(), obtains the new subscriptionId, and updates the queue mapping

### Why direct ws.send() / ws.recv() instead of ws_api.request()

_handle_reconnect is called from inside the call chain: _read_loop() → _run_reconnect() → connect() → _after_connect(). At this point _read_loop is suspended — it cannot process incoming messages until _after_connect() returns. If we used ws_api.request(), it would create a future and wait for _read_loop to resolve it, but _read_loop is waiting for us to finish first. This causes a deadlock (timeout after TIMEOUT seconds). Sending and receiving directly on the raw websocket avoids this since we don't depend on _read_loop to deliver the response.

### Notes
This PR may need further refinement. I intentionally kept the changes non-invasive to avoid disrupting the existing architecture. A more thorough solution might involve rethinking how KeepAliveWebsocket relates to WebsocketAPI for shared-connection subscription types, but that would be a larger effort.