### PR TITLE
fix: guard WebSocketClientProtocol import behind TYPE_CHECKING (fixes #1666)

### DIFF
--- a/binance/ws/websocket_api.py
+++ b/binance/ws/websocket_api.py
@@ -1,7 +1,8 @@
-from typing import Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional
 import asyncio
 
-from websockets import WebSocketClientProtocol  # type: ignore
+if TYPE_CHECKING:
+    from websockets import WebSocketClientProtocol  # type: ignore  # noqa: F401
 
 from .constants import WSListenerState
 from .reconnecting_websocket import ReconnectingWebsocket
@@ -117,7 +118,7 @@ class WebsocketAPI(ReconnectingWebsocket):
             try:
                 if (
                     self.ws is None
-                    or (isinstance(self.ws, WebSocketClientProtocol) and self.ws.closed)
+                    or (hasattr(self.ws, "closed") and self.ws.closed)
                     or self.ws_state != WSListenerState.STREAMING
                 ):
                     await self.connect()


### PR DESCRIPTION
## Problem

With `websockets>=14`, the runtime import of `WebSocketClientProtocol` triggers a `DeprecationWarning`:

```
DeprecationWarning: websockets.WebSocketClientProtocol is deprecated
DeprecationWarning: websockets.legacy is deprecated
```

This comes from `binance/ws/websocket_api.py:4` where the class is imported unconditionally, but only used for type hints and a runtime `isinstance` check.

## Fix

- **Wrap the import in `TYPE_CHECKING`**: The class is only needed for static type hints, so moving it behind the guard removes the runtime import warning entirely.
- **Replace `isinstance` with `hasattr`**: Since the class is no longer available at runtime, the check for `ws.closed` now uses `hasattr` instead.

No behavioral change — the WebSocket connection logic remains identical.

Addresses #1666.